### PR TITLE
Moab4.9.0 update

### DIFF
--- a/make_watertight/arc.cpp
+++ b/make_watertight/arc.cpp
@@ -631,8 +631,11 @@ namespace arc {
         if( facet_tol < dist ) continue;
 
         // THE CURVE WILL BE MERGED
-	std::cout << "  merging curve " << j_id << " to curve " << i_id 
-                  << ", dist_between_curves=" << dist << " cm" << std::endl;
+        if (debug)
+	  {
+	    std::cout << "  merging curve " << j_id << " to curve " << i_id 
+                      << ", dist_between_curves=" << dist << " cm" << std::endl;
+	  }
 
         // Merge the endpts of the curve to preserve topology. Merging (and deleting)
         // the endpoints will also remove them from the KDtree so that the merged

--- a/make_watertight/arc.hpp
+++ b/make_watertight/arc.hpp
@@ -2,59 +2,59 @@
 #define ARC_HPP
 
 #include <vector>
-#include "MBCore.hpp"
+#include "moab/Core.hpp"
 #include "gen.hpp"
-#include "MBSkinner.hpp"
+#include "moab/Skinner.hpp"
 #include "MBTagConventions.hpp"
 
-MBInterface *MBI(); 
+moab::Interface *MBI(); 
 namespace arc {
 
 /// check that edge is going in the same direction as one of the edges on tri.
 /// If this is not the case, the edge is reversed.
-  MBErrorCode orient_edge_with_tri( const MBEntityHandle edge, 
-                                    const MBEntityHandle tri );
-// checks for degeneracy of edges in the MBRange edges and deletes degenerates if found
-  MBErrorCode remove_degenerate_edges( MBRange &edges, const bool debug );
+  moab::ErrorCode orient_edge_with_tri( const moab::EntityHandle edge, 
+                                    const moab::EntityHandle tri );
+// checks for degeneracy of edges in the moab::Range edges and deletes degenerates if found
+  moab::ErrorCode remove_degenerate_edges( moab::Range &edges, const bool debug );
 
-/// deletes any duplicate edges in MBRange edges for which one goes from vertex a to 
+/// deletes any duplicate edges in moab::Range edges for which one goes from vertex a to 
 /// vertex b and the other from b to a
-  MBErrorCode remove_opposite_pairs_of_edges( MBRange &edges, const bool debug );
-  MBErrorCode remove_opposite_pairs_of_edges_fast( MBRange &edges, const bool debug );
+  moab::ErrorCode remove_opposite_pairs_of_edges( moab::Range &edges, const bool debug );
+  moab::ErrorCode remove_opposite_pairs_of_edges_fast( moab::Range &edges, const bool debug );
 
-  MBErrorCode get_next_oriented_edge( const MBRange edges, 
-                                      const MBEntityHandle edge,
-				      MBEntityHandle &next_edge );
+  moab::ErrorCode get_next_oriented_edge( const moab::Range edges, 
+                                      const moab::EntityHandle edge,
+				      moab::EntityHandle &next_edge );
 
   // Given a range of edges and a vertex, find the edge the contains the
   // endpoint. Also return the opposite endpoint of the edge. This checks
   // to ensure that only one edge is found.
-  MBErrorCode get_next_edge_and_vert_by_edge( const MBRange edges_in,
-					      const MBEntityHandle edge_in,
-					      const MBEntityHandle vertex_in,
-					      MBEntityHandle &edge_out,
-					      MBEntityHandle &vertex_out       );
+  moab::ErrorCode get_next_edge_and_vert_by_edge( const moab::Range edges_in,
+					      const moab::EntityHandle edge_in,
+					      const moab::EntityHandle vertex_in,
+					      moab::EntityHandle &edge_out,
+					      moab::EntityHandle &vertex_out       );
 
-  MBErrorCode create_loops_from_oriented_edges_fast( MBRange edges,
-						std::vector< std::vector<MBEntityHandle> > &loops_of_edges,
+  moab::ErrorCode create_loops_from_oriented_edges_fast( moab::Range edges,
+						std::vector< std::vector<moab::EntityHandle> > &loops_of_edges,
                                                 const bool debug );
-  MBErrorCode create_loops_from_oriented_edges( MBRange edges,
-						std::vector< std::vector<MBEntityHandle> > &loops_of_edges,
+  moab::ErrorCode create_loops_from_oriented_edges( moab::Range edges,
+						std::vector< std::vector<moab::EntityHandle> > &loops_of_edges,
                                                 const bool debug );
 
-  MBErrorCode order_verts_by_edge( MBRange unordered_edges, std::vector<MBEntityHandle> &ordered_verts );
+  moab::ErrorCode order_verts_by_edge( moab::Range unordered_edges, std::vector<moab::EntityHandle> &ordered_verts );
 
 /// gets the moab entities in the meshset, set, and returns them to vec
-  MBErrorCode get_meshset( const MBEntityHandle set, std::vector<MBEntityHandle> &vec);
+  moab::ErrorCode get_meshset( const moab::EntityHandle set, std::vector<moab::EntityHandle> &vec);
 
 /// clears the given meshset set and then adds the entities desired to the meshset
 /// (apparently child_parent_relations are taken care of here? Edges are created how?)
-  MBErrorCode set_meshset( const MBEntityHandle set, const std::vector<MBEntityHandle> vec );
+  moab::ErrorCode set_meshset( const moab::EntityHandle set, const std::vector<moab::EntityHandle> vec );
 
 /// goes through curve_sets and finds any curves with coincident ( dist. apart <= FACET_TOL) front and back points.
 /// it then merges the curves topologically. Any merged curves aren't deleted until prepare surfaces. 
-  MBErrorCode merge_curves(MBRange curve_sets, const double FACET_TOL,
-                           MBTag idTag, MBTag merge_tag, const bool debug );
+  moab::ErrorCode merge_curves(moab::Range curve_sets, const double FACET_TOL,
+                           moab::Tag idTag, moab::Tag merge_tag, const bool debug );
 }
 
 #endif

--- a/make_watertight/check_watertight.cpp
+++ b/make_watertight/check_watertight.cpp
@@ -34,17 +34,17 @@
 #include <vector>
 #include <set>
 #include <algorithm>
-#include "MBCore.hpp"
+#include "moab/Core.hpp"
 #include "MBTagConventions.hpp"
-#include "MBRange.hpp"
-#include "MBSkinner.hpp"
+#include "moab/Range.hpp"
+#include "moab/Skinner.hpp"
 
 #include "cw_func.hpp"
 #include "gen.hpp"
 #include "arc.hpp"
 #include "zip.hpp"
 
-MBInterface *MBI();
+moab::Interface *MBI();
 
 // struct to hold coordinates of skin edge, it's surface id, and a matched flag
 struct coords_and_id {
@@ -56,8 +56,8 @@ struct coords_and_id {
   double z2;
   int  surf_id;
   bool matched;
-  MBEntityHandle vert1;
-  MBEntityHandle vert2;
+  moab::EntityHandle vert1;
+  moab::EntityHandle vert2;
 };
 
 /* qsort struct comparision function */
@@ -135,17 +135,17 @@ int main(int argc, char **argv)
     }
 
   // load file and get tolerance from input argument
-  MBErrorCode result;
+  moab::ErrorCode result;
   std::string filename = argv[1]; //set filename
-  MBEntityHandle input_set;
-  result = MBI()->create_meshset( MESHSET_SET, input_set ); //create handle to meshset
-  if(MB_SUCCESS != result) 
+  moab::EntityHandle input_set;
+  result = MBI()->create_meshset( moab::MESHSET_SET, input_set ); //create handle to meshset
+  if(moab::MB_SUCCESS != result) 
     {
       return result;
     }
 
   result = MBI()->load_file( filename.c_str(), &input_set ); //load the file into the meshset
-  if(MB_SUCCESS != result) 
+  if(moab::MB_SUCCESS != result) 
     {
       // failed to load the file
       std::cout << "could not load file" << std::endl;
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
   // is the order of the optional variables going to be a problem?
   // (i.e. we 'skipped' the variable test)
   result=cw_func::check_mesh_for_watertightness( input_set, tol, sealed, test, verbose, check_topology);
-  if(gen::error(MB_SUCCESS!=result, "could not check model for watertightness")) return result;
+  if(gen::error(moab::MB_SUCCESS!=result, "could not check model for watertightness")) return result;
 
   clock_t end_time = clock();
   std::cout << (double) (end_time-start_time)/CLOCKS_PER_SEC << " seconds" << std::endl;
@@ -193,7 +193,7 @@ int main(int argc, char **argv)
 }
 
 
-MBInterface* MBI() {
-  static MBCore instance;
+moab::Interface* MBI() {
+  static moab::Core instance;
   return &instance;
 }

--- a/make_watertight/cleanup.cpp
+++ b/make_watertight/cleanup.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include "cleanup.hpp"
 //#include "MBAdaptiveKDTree.hpp"
-#include "MBOrientedBoxTreeTool.hpp"
+#include "moab/OrientedBoxTreeTool.hpp"
 
 namespace cleanup {
   // The obbtrees are no longer valid because the triangles have been altered.
@@ -10,163 +10,163 @@ namespace cleanup {
   //  -Surface/volume set handles are added to the root meshset.
   // Somehow, delete the old tree without deleting the
   // surface and volume sets, then build a new tree.
-  MBErrorCode remove_obb_tree(bool verbose) {
-    MBErrorCode result;
-    MBRange obb_entities;
-    MBTag obbTag;
-    result = MBI()->tag_get_handle( "OBB_TREE", sizeof(MBEntityHandle),
-	       		  MB_TYPE_HANDLE, obbTag, MB_TAG_DENSE, NULL, 0 );
+  moab::ErrorCode remove_obb_tree(bool verbose) {
+    moab::ErrorCode result;
+    moab::Range obb_entities;
+    moab::Tag obbTag;
+    result = MBI()->tag_get_handle( "OBB_TREE", sizeof(moab::EntityHandle),
+	       		  moab::MB_TYPE_HANDLE, obbTag, moab::MB_TAG_DENSE, NULL, 0 );
     if(verbose)
     {
-    if(gen::error(MB_SUCCESS != result, "could not get OBB tree handle")) return result;
+    if(gen::error(moab::MB_SUCCESS != result, "could not get OBB tree handle")) return result;
     }
     else
     {
-    if(gen::error(MB_SUCCESS != result, "")) return result;
+    if(gen::error(moab::MB_SUCCESS != result, "")) return result;
     }
     // This gets the surface/volume sets. I don't want to delete the sets.
     // I want to remove the obbTag that contains the tree root handle and
     // delete the tree.
-    result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET,
+    result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET,
 						    &obbTag, 0, 1, obb_entities );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     std::cout << "  found " << obb_entities.size() << " OBB entities" << std::endl;
     //gen::print_range( obb_entities );
     //result = MBI()->delete_entities( obb_entities );
  
     // find tree roots
-    MBRange trees;
-    MBOrientedBoxTreeTool tool( MBI() );
-    MBTag rootTag;
-    for(MBRange::iterator i=obb_entities.begin(); i!=obb_entities.end(); i++) {
-      MBEntityHandle root;
+    moab::Range trees;
+    moab::OrientedBoxTreeTool tool( MBI() );
+    moab::Tag rootTag;
+    for(moab::Range::iterator i=obb_entities.begin(); i!=obb_entities.end(); i++) {
+      moab::EntityHandle root;
       result = MBI()->tag_get_data( obbTag, &(*i), 1, &root );
-      if(gen::error(MB_SUCCESS!=result, "coule not get OBB tree data")) return result;
-      //assert(MB_SUCCESS == result);
+      if(gen::error(moab::MB_SUCCESS!=result, "coule not get OBB tree data")) return result;
+      //assert(moab::MB_SUCCESS == result);
       tool.delete_tree( root );
     }
     result = MBI()->tag_delete( obbTag ); // use this for DENSE tags
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
 
 
     result = MBI()->tag_get_handle ( "OBB", sizeof(double), 
-     				  MB_TYPE_DOUBLE, rootTag, MB_TAG_SPARSE, 0, false);
-    assert(MB_SUCCESS==result || MB_ALREADY_ALLOCATED==result);
-    /*    result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET, &rootTag, 
+     				  moab::MB_TYPE_DOUBLE, rootTag, moab::MB_TAG_SPARSE, 0, false);
+    assert(moab::MB_SUCCESS==result || moab::MB_ALREADY_ALLOCATED==result);
+    /*    result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET, &rootTag, 
                                                    NULL, 1, trees );
-    if(MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
-    assert(MB_SUCCESS == result);
+    if(moab::MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
+    assert(moab::MB_SUCCESS == result);
     //tool.find_all_trees( trees );
     std::cout << trees.size() << " tree(s) contained in file" << std::endl;
     //gen::print_range( trees );
   
     // delete the trees
-    for (MBRange::iterator i = trees.begin(); i != trees.end(); ++i) {
+    for (moab::Range::iterator i = trees.begin(); i != trees.end(); ++i) {
       result = tool.delete_tree( *i );
-      //if(MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
-      //assert(MB_SUCCESS == result);
+      //if(moab::MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
+      //assert(moab::MB_SUCCESS == result);
     }
     */ 
     // Were all of the trees deleted? Perhaps some of the roots we found were
     // child roots that got deleted with their parents.
     trees.clear();
-    result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET, &rootTag,
+    result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET, &rootTag,
 						    NULL, 1, trees );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     std::cout << "  " << trees.size() << " OBB tree(s) contained in file" << std::endl;
-    return MB_SUCCESS;  
+    return moab::MB_SUCCESS;  
   }
 
-  MBErrorCode delete_small_edge_and_tris( const MBEntityHandle vert0, 
-                                          MBEntityHandle &vert1,
+  moab::ErrorCode delete_small_edge_and_tris( const moab::EntityHandle vert0, 
+                                          moab::EntityHandle &vert1,
                                           const double tol ) {
     // If the verts are the same, this is not meaningful.
-    if(vert0 == vert1) return MB_SUCCESS;
-    MBErrorCode result;
+    if(vert0 == vert1) return moab::MB_SUCCESS;
+    moab::ErrorCode result;
 
     // If the edge is small, delete it and the adjacent tris.
     if(tol > gen::dist_between_verts(vert0, vert1)) {
       // get tris to delete
-      MBRange tris;              
-      MBEntityHandle verts[2] = {vert0, vert1};                      
+      moab::Range tris;              
+      moab::EntityHandle verts[2] = {vert0, vert1};                      
       result = MBI()->get_adjacencies( verts, 2, 2, false, tris );                   
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       result = MBI()->delete_entities( tris );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       std::cout << "delete_small_edge_and_tris: deleted " << tris.size() 
                 << " tris." << std::endl;
       // now merge the verts, keeping the first one
       // IN FUTURE, AVERAGE THE LOCATIONS???????????
       result = MBI()->merge_entities( vert0, vert1, false, true);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       vert1 = vert0;
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode delete_small_edges(const MBRange &surfaces, const double FACET_TOL) {
+  moab::ErrorCode delete_small_edges(const moab::Range &surfaces, const double FACET_TOL) {
     // PROBLEM: THIS IS INVALID BECAUSE TRIS CAN HAVE LONG EDGES BUT
     // SMALL AREA. All three pts are in a line. This is the nature of
     // faceting vs. meshing.
     /* Remove small triangles by removing edges that are too small. 
     Remove small edges by merging their endpoints together, creating
     degenerate triangles. Delete the degenerate triangles. */
-    MBErrorCode result;
-    for(MBRange::const_iterator i=surfaces.begin(); i!=surfaces.end(); i++) {
+    moab::ErrorCode result;
+    for(moab::Range::const_iterator i=surfaces.begin(); i!=surfaces.end(); i++) {
       std::cout << "surf_id=" << gen::geom_id_by_handle(*i) << std::endl;
 
       // get all tris
-      MBRange tris;
-      result = MBI()->get_entities_by_type( *i, MBTRI, tris );
-      assert(MB_SUCCESS == result);
+      moab::Range tris;
+      result = MBI()->get_entities_by_type( *i, moab::MBTRI, tris );
+      assert(moab::MB_SUCCESS == result);
 
       // Check to ensure there area no degenerate tris
-      for(MBRange::iterator j=tris.begin(); j!=tris.end(); j++) {
+      for(moab::Range::iterator j=tris.begin(); j!=tris.end(); j++) {
         // get endpts
-        const MBEntityHandle *endpts;                                
+        const moab::EntityHandle *endpts;                                
         int n_verts;                                      
         result = MBI()->get_connectivity( *j, endpts, n_verts);
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(3 == n_verts);
         assert( endpts[0]!=endpts[1] && endpts[1]!=endpts[2] );
       }
 
 
       // get the skin first, because my find_skin does not check before creating edges.
-      MBRange skin_edges;
+      moab::Range skin_edges;
       //result = gen::find_skin( tris, 1, skin_edges, false );
-      MBSkinner tool(MBI());
+      moab::Skinner tool(MBI());
       result = tool.find_skin( 0 , tris, 1, skin_edges, false );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
 
       // create the edges
-      MBRange edges;
-      result = MBI()->get_adjacencies( tris, 1, true, edges, MBInterface::UNION );
-      if(MB_SUCCESS != result) {
+      moab::Range edges;
+      result = MBI()->get_adjacencies( tris, 1, true, edges, moab::Interface::UNION );
+      if(moab::MB_SUCCESS != result) {
 	std::cout << "result=" << result << std::endl;
       }
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
 
       // get the internal edges
-      MBRange internal_edges = subtract(edges, skin_edges);
+      moab::Range internal_edges = subtract(edges, skin_edges);
 
-      for(MBRange::iterator j=internal_edges.begin(); j!=internal_edges.end(); j++) {
+      for(moab::Range::iterator j=internal_edges.begin(); j!=internal_edges.end(); j++) {
         int n_internal_edges = internal_edges.size();
 	std::cout << "edge=" << *j << std::endl;
         MBI()->list_entity( *j );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
 
         // get endpts
-        const MBEntityHandle *endpts;                                
+        const moab::EntityHandle *endpts;                                
         int n_verts;                                      
         result = MBI()->get_connectivity( *j, endpts, n_verts);
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(2 == n_verts);
 
         // does another edge exist w the same endpts? Why would it?
-        MBRange duplicate_edges;
+        moab::Range duplicate_edges;
         result = MBI()->get_adjacencies( endpts, 2, 1, true, duplicate_edges );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         if(1 < duplicate_edges.size()) MBI()->list_entities( duplicate_edges );
         assert(1 == duplicate_edges.size());
 
@@ -174,39 +174,39 @@ namespace cleanup {
         if(FACET_TOL < gen::dist_between_verts( endpts[0], endpts[1] )) continue; 
  
         // quick check
-        for(MBRange::iterator k=internal_edges.begin(); k!=internal_edges.end(); k++) {
-          const MBEntityHandle *epts;                                
+        for(moab::Range::iterator k=internal_edges.begin(); k!=internal_edges.end(); k++) {
+          const moab::EntityHandle *epts;                                
           int n_vts;                                      
           result = MBI()->get_connectivity( *k, epts, n_vts);
-          assert(MB_SUCCESS == result);
+          assert(moab::MB_SUCCESS == result);
           assert(2 == n_vts);
 	  // The skin edges/verts cannot be moved, therefore both endpoints cannot 
 	  // be on the skin. If they are, continue.
-	  MBRange adj_edges0;
+	  moab::Range adj_edges0;
 	  result = MBI()->get_adjacencies( &epts[0], 1, 1, true, adj_edges0 );
-	  assert(MB_SUCCESS == result);
+	  assert(moab::MB_SUCCESS == result);
 	  if(3 > adj_edges0.size()) {
 	    std::cout << "adj_edges0.size()=" << adj_edges0.size() 
 		      << " epts[0]=" << epts[0] << std::endl;
 	    MBI()->list_entity( epts[0] );
 	    //MBI()->write_mesh( "test_output.h5m" );
-	    assert(MB_SUCCESS == result);
+	    assert(moab::MB_SUCCESS == result);
 	  }
 	  assert(3 <= adj_edges0.size());
-	  MBRange adj_skin_edges0 = intersect( adj_edges0, skin_edges );
+	  moab::Range adj_skin_edges0 = intersect( adj_edges0, skin_edges );
 	  bool endpt0_is_skin;
 	  if(adj_skin_edges0.empty()) endpt0_is_skin = false;
 	  else endpt0_is_skin = true;
 
-	  MBRange adj_edges1;
+	  moab::Range adj_edges1;
 	  result = MBI()->get_adjacencies( &epts[1], 1, 1, true, adj_edges1 );
-	  assert(MB_SUCCESS == result);
+	  assert(moab::MB_SUCCESS == result);
 	  if(3 > adj_edges1.size()) {
 	    std::cout << "adj_edges1.size()=" << adj_edges1.size() 
 		      << " epts[1]=" << epts[1] << std::endl;
 	    MBI()->list_entity( epts[1] );
 	    //MBI()->write_mesh( "test_output.h5m" );
-	    assert(MB_SUCCESS == result);
+	    assert(moab::MB_SUCCESS == result);
 	  }
 	  assert(3 <= adj_edges1.size());
         }
@@ -214,41 +214,41 @@ namespace cleanup {
 
         // The skin edges/verts cannot be moved, therefore both endpoints cannot 
         // be on the skin. If they are, continue.
-        MBRange adj_edges0;
+        moab::Range adj_edges0;
         result = MBI()->get_adjacencies( &endpts[0], 1, 1, true, adj_edges0 );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         if(3 > adj_edges0.size()) {
           std::cout << "adj_edges0.size()=" << adj_edges0.size() 
                     << " endpts[0]=" << endpts[0] << std::endl;
           MBI()->list_entity( endpts[0] );
           //MBI()->write_mesh( "test_output.h5m" );
-          assert(MB_SUCCESS == result);
+          assert(moab::MB_SUCCESS == result);
         }
         assert(3 <= adj_edges0.size());
-        MBRange adj_skin_edges0 = intersect( adj_edges0, skin_edges );
+        moab::Range adj_skin_edges0 = intersect( adj_edges0, skin_edges );
         bool endpt0_is_skin;
         if(adj_skin_edges0.empty()) endpt0_is_skin = false;
         else endpt0_is_skin = true;
 
-        MBRange adj_edges1;
+        moab::Range adj_edges1;
         result = MBI()->get_adjacencies( &endpts[1], 1, 1, true, adj_edges1 );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         if(3 > adj_edges1.size()) {
           std::cout << "adj_edges1.size()=" << adj_edges1.size() 
                     << " endpts[1]=" << endpts[1] << std::endl;
           MBI()->list_entity( endpts[1] );
           //MBI()->write_mesh( "test_output.h5m" );
-          assert(MB_SUCCESS == result);
+          assert(moab::MB_SUCCESS == result);
         }
         assert(3 <= adj_edges1.size());
-        MBRange adj_skin_edges1 = intersect( adj_edges1, skin_edges );
+        moab::Range adj_skin_edges1 = intersect( adj_edges1, skin_edges );
         bool endpt1_is_skin;
         if(adj_skin_edges1.empty()) endpt1_is_skin = false;
         else endpt1_is_skin = true;
         if(endpt0_is_skin && endpt1_is_skin) continue;
         
         // Keep the skin endpt, and delete the other endpt
-        MBEntityHandle keep_endpt, delete_endpt;
+        moab::EntityHandle keep_endpt, delete_endpt;
         if(endpt0_is_skin) {
           keep_endpt   = endpts[0];
           delete_endpt = endpts[1];
@@ -258,9 +258,9 @@ namespace cleanup {
         }
 
         // get the adjacent tris
-	std::vector<MBEntityHandle> adj_tris;
+	std::vector<moab::EntityHandle> adj_tris;
         result = MBI()->get_adjacencies( &(*j), 1, 2, false, adj_tris );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
 	        if(2 != adj_tris.size()) {
 	std::cout << "adj_tris.size()=" << adj_tris.size() << std::endl;
 	for(unsigned int i=0; i<adj_tris.size(); i++) gen::print_triangle( adj_tris[i], true );
@@ -269,34 +269,34 @@ namespace cleanup {
  
         // When merging away an edge, a tri and 2 edges will be deleted.
         // Get each triangle's edge other edge the will be deleted.
-        MBRange tri0_delete_edge_verts;
+        moab::Range tri0_delete_edge_verts;
         result = MBI()->get_adjacencies( &adj_tris[0], 1, 0, true, tri0_delete_edge_verts );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(3 == tri0_delete_edge_verts.size());
         tri0_delete_edge_verts.erase( keep_endpt );
-        MBRange tri0_delete_edge;
+        moab::Range tri0_delete_edge;
         result = MBI()->get_adjacencies( tri0_delete_edge_verts, 1, true, tri0_delete_edge );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(1 == tri0_delete_edge.size());      
  
-        MBRange tri1_delete_edge_verts;
+        moab::Range tri1_delete_edge_verts;
         result = MBI()->get_adjacencies( &adj_tris[1], 1, 0, true, tri1_delete_edge_verts );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(3 == tri1_delete_edge_verts.size());
         tri1_delete_edge_verts.erase( keep_endpt );
-        MBRange tri1_delete_edge;
+        moab::Range tri1_delete_edge;
         result = MBI()->get_adjacencies( tri1_delete_edge_verts, 1, true, tri1_delete_edge );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(1 == tri1_delete_edge.size());      
 
         // When an edge is merged, it will be deleted and its to adjacent tris
         // will be deleted because they are degenerate. We cannot alter the skin.
         // How many skin edges does tri0 have?
-	/*        MBRange tri_edges;
+	/*        moab::Range tri_edges;
         result = MBI()->get_adjacencies( &adj_tris[0], 1, 1, false, tri_edges );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(3 == tri_edges.size());
-        MBRange tri0_internal_edges = intersect(tri_edges, internal_edges);
+        moab::Range tri0_internal_edges = intersect(tri_edges, internal_edges);
 
         // Cannot merge the edge away if the tri has more than one skin edge.
         // Otherwise we would delete a skin edge. We already know the edges in 
@@ -306,13 +306,13 @@ namespace cleanup {
         // check the other tri
         tri_edges.clear();
         result = MBI()->get_adjacencies( &adj_tris[1], 1, 1, false, tri_edges );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(3 == tri_edges.size());
-        MBRange tri1_internal_edges = intersect(tri_edges, internal_edges);
+        moab::Range tri1_internal_edges = intersect(tri_edges, internal_edges);
         if(2 > tri1_internal_edges.size()) continue;
 
         // Check to make sure that the internal edges are not on the skin
-        MBRange temp;
+        moab::Range temp;
         temp = intersect( tri0_internal_edges, skin_edges );
         assert(temp.empty());
         temp = intersect( tri1_internal_edges, skin_edges );
@@ -321,9 +321,9 @@ namespace cleanup {
         // We know that the edge will be merged away. Find the keep_vert and
         // delete_vert. The delete_vert should never be a skin vertex because the
         // skin must not move.
-        MBRange delete_vert;
+        moab::Range delete_vert;
         result = MBI()->get_adjacencies( tri0_internal_edges, 0, false, delete_vert);
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(1 == delete_vert.size());        
 	*/
 
@@ -332,23 +332,23 @@ namespace cleanup {
         // cases to avoid all result in inverted tris.
         // *********************************************************************
         // get all the tris adjacent to the point the will be moved.
-        MBRange altered_tris;
+        moab::Range altered_tris;
         result = MBI()->get_adjacencies( &delete_endpt, 1, 2, false, altered_tris );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         bool inverted_tri = false;
-        for(MBRange::const_iterator k=altered_tris.begin(); k!=altered_tris.end(); ++k) {
-          const MBEntityHandle *conn;
+        for(moab::Range::const_iterator k=altered_tris.begin(); k!=altered_tris.end(); ++k) {
+          const moab::EntityHandle *conn;
           int n_verts;
           result = MBI()->get_connectivity( *k, conn, n_verts );
-          assert(MB_SUCCESS == result);
+          assert(moab::MB_SUCCESS == result);
           assert(3 == tris.size());
-          MBEntityHandle new_conn[3];
+          moab::EntityHandle new_conn[3];
           for(unsigned int i=0; i<3; ++i) {
             new_conn[i] = (conn[i]==delete_endpt) ? keep_endpt : conn[i];
           }
           double area;
           result = gen::triangle_area( new_conn, area );
-          assert(MB_SUCCESS == result);
+          assert(moab::MB_SUCCESS == result);
           if(0 > area) {
 	    std::cout << "inverted tri detected, area=" << area << std::endl;
             inverted_tri = true;
@@ -370,31 +370,31 @@ namespace cleanup {
 	MBI()->list_entity( keep_endpt );
 	MBI()->list_entity( delete_endpt );
         result = MBI()->merge_entities( keep_endpt, delete_endpt, false, true );          
-	assert(MB_SUCCESS == result);
+	assert(moab::MB_SUCCESS == result);
         result = MBI()->delete_entities( tri0_delete_edge );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         result = MBI()->delete_entities( tri1_delete_edge );
-        assert(MB_SUCCESS == result);        
+        assert(moab::MB_SUCCESS == result);        
         result = MBI()->delete_entities( &(*j), 1 );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
 	std::cout << "deleted edges=" << *j << " " << tri0_delete_edge.front()
                   << " " << tri1_delete_edge.front() << std::endl;
 	          
 	// delete degenerate tris                          
 	result = MBI()->delete_entities( &adj_tris[0], 2 );                 
-	assert(MB_SUCCESS == result); 
+	assert(moab::MB_SUCCESS == result); 
 	MBI()->list_entity( keep_endpt );
 
         // remove the edge from the range
         j = internal_edges.erase(*j) - 1; 
 	std::cout << "next iter=" << *j << std::endl;        
 
-        MBRange new_tris;
-        result = MBI()->get_entities_by_type( *i, MBTRI, new_tris );
-        assert(MB_SUCCESS == result);
-        MBRange new_skin_edges;
+        moab::Range new_tris;
+        result = MBI()->get_entities_by_type( *i, moab::MBTRI, new_tris );
+        assert(moab::MB_SUCCESS == result);
+        moab::Range new_skin_edges;
         result = tool.find_skin( *i, new_tris, 1, new_skin_edges, false );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         assert(skin_edges.size() == new_skin_edges.size());
         for(unsigned int k=0; k<skin_edges.size(); k++) {
           if(skin_edges[k] != new_skin_edges[k]) {
@@ -407,38 +407,38 @@ namespace cleanup {
       }
   
       // cleanup edges
-      result = MBI()->get_entities_by_type( 0, MBEDGE, edges );
-      assert(MB_SUCCESS == result);
+      result = MBI()->get_entities_by_type( 0, moab::MBEDGE, edges );
+      assert(moab::MB_SUCCESS == result);
       result = MBI()->delete_entities( edges ); 
-      assert(MB_SUCCESS == result); 
+      assert(moab::MB_SUCCESS == result); 
    
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   } 
   
   // Lots of edges have been created but are no longer needed.
   // Delete edges that are not in curves. These should be the only edges
   // that remain. This incredibly speeds up the watertight_check tool (100x?).
-  MBErrorCode cleanup_edges( MBRange curve_meshsets ) {
-    MBErrorCode result;
-    MBRange edges, edges_to_keep;
-    for(MBRange::iterator i=curve_meshsets.begin(); i!=curve_meshsets.end(); i++) {
+  moab::ErrorCode cleanup_edges( moab::Range curve_meshsets ) {
+    moab::ErrorCode result;
+    moab::Range edges, edges_to_keep;
+    for(moab::Range::iterator i=curve_meshsets.begin(); i!=curve_meshsets.end(); i++) {
       result = MBI()->get_entities_by_dimension( *i, 1, edges );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       edges_to_keep.merge( edges );
     }
 
-    MBRange all_edges;
+    moab::Range all_edges;
     result = MBI()->get_entities_by_dimension( 0, 1, all_edges );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
 
     // delete the edges that are not in curves.
-    //MBRange edges_to_delete = all_edges.subtract( edges_to_keep );
-    MBRange edges_to_delete = subtract( all_edges, edges_to_keep );
+    //moab::Range edges_to_delete = all_edges.subtract( edges_to_keep );
+    moab::Range edges_to_delete = subtract( all_edges, edges_to_keep );
     std::cout << "deleting " << edges_to_delete.size() << " unused edges" << std::endl;
     result = MBI()->delete_entities( edges_to_delete );
-    assert(MB_SUCCESS == result);
-    return MB_SUCCESS;
+    assert(moab::MB_SUCCESS == result);
+    return moab::MB_SUCCESS;
   }
  
   

--- a/make_watertight/cleanup.hpp
+++ b/make_watertight/cleanup.hpp
@@ -1,12 +1,12 @@
 #ifndef CLEANUP_HPP
 #define CLEANUP_HPP
 
-#include "MBCore.hpp"
+#include "moab/Core.hpp"
 #include "gen.hpp"
 #include "arc.hpp"
 #include "zip.hpp"
 
-MBInterface *MBI();
+moab::Interface *MBI();
 namespace cleanup {
 
   /// The obbtrees are no longer valid because the triangles have been altered.
@@ -15,16 +15,16 @@ namespace cleanup {
   ///  -Surface/volume set handles are added to the root meshset.
   /// Somehow, delete the old tree without deleting the
   /// surface and volume sets, then build a new tree.
-  MBErrorCode remove_obb_tree(bool verbose = false);
+  moab::ErrorCode remove_obb_tree(bool verbose = false);
 
-  MBErrorCode delete_small_edge_and_tris( const MBEntityHandle vert0, 
-                                          MBEntityHandle &vert1, const double tol);
-  MBErrorCode delete_small_edges( const MBRange &surfaces, const double MERGE_TOL);
+  moab::ErrorCode delete_small_edge_and_tris( const moab::EntityHandle vert0, 
+                                          moab::EntityHandle &vert1, const double tol);
+  moab::ErrorCode delete_small_edges( const moab::Range &surfaces, const double MERGE_TOL);
 
   /// Lots of edges have been created but are no longer needed.
   /// Delete edges that are not in curves. These should be the only edges
   /// that remain. This incredibly speeds up the watertight_check tool (100x?).
-  MBErrorCode cleanup_edges( MBRange curve_meshsets );  
+  moab::ErrorCode cleanup_edges( moab::Range curve_meshsets );  
 }
 
 #endif

--- a/make_watertight/cw_func.hpp
+++ b/make_watertight/cw_func.hpp
@@ -9,18 +9,18 @@
 #include <time.h>
 #include <vector>
 #include <algorithm>
-#include "MBCore.hpp"
-#include "MBRange.hpp"
-#include "MBAdaptiveKDTree.hpp" // for merging verts
-#include "MBCartVect.hpp"
+#include "moab/Core.hpp"
+#include "moab/Range.hpp"
+#include "moab/AdaptiveKDTree.hpp" // for merging verts
+#include "moab/CartVect.hpp"
 
 
-MBInterface *MBI();
+moab::Interface *MBI();
 namespace cw_func {
 /// checks the input mesh for watertightness. If check_topology=true, then the mesh will be checked topologically only, no tolerances allowed.
 /// If check_topology = false, then the model will be checked for watertightness by proximity.
 /// (i.e. so long as paired vertices are within tol of each other, the mesh will be considered watertight)
- MBErrorCode check_mesh_for_watertightness( MBEntityHandle input_set, double tol, bool &sealed, bool test = false,  bool verbose = false , bool check_topology = false );
+ moab::ErrorCode check_mesh_for_watertightness( moab::EntityHandle input_set, double tol, bool &sealed, bool test = false,  bool verbose = false , bool check_topology = false );
 
  int compare_by_coords(const void *a, const void *b);
  
@@ -35,8 +35,8 @@ namespace cw_func {
   double z2;
   int  surf_id;
   bool matched;
-  MBEntityHandle vert1;
-  MBEntityHandle vert2;
+  moab::EntityHandle vert1;
+  moab::EntityHandle vert2;
 };
 
 }

--- a/make_watertight/gen.cpp
+++ b/make_watertight/gen.cpp
@@ -2141,7 +2141,6 @@ MBErrorCode get_sealing_mesh_tags( double &facet_tol,
 	void *val[] = {&dim};
 	result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET, &geom_tag,
 	  					    val, 1, geometry_sets[dim] );
-        if(verbose) std::cout << "Get entities by type and tag" << std::endl;
 	assert(MB_SUCCESS == result);
 
 	// make sure that sets TRACK membership and curves are ordered

--- a/make_watertight/gen.cpp
+++ b/make_watertight/gen.cpp
@@ -11,7 +11,7 @@
 
 #include "gen.hpp"
 #include "zip.hpp"
-#include "MBSkinner.hpp"
+#include "moab/Skinner.hpp"
 
 
 const char GEOM_SENSE_2_TAG_NAME[] = "GEOM_SENSE_2";
@@ -34,59 +34,59 @@ namespace gen {
     }
   }
 
-void moab_printer(MBErrorCode error_code)
+void moab_printer(moab::ErrorCode error_code)
 {
-  if ( error_code == MB_INDEX_OUT_OF_RANGE )
+  if ( error_code == moab::MB_INDEX_OUT_OF_RANGE )
     {
-      std::cerr << "ERROR: MB_INDEX_OUT_OF_RANGE" << std::endl;
+      std::cerr << "ERROR: moab::MB_INDEX_OUT_OF_RANGE" << std::endl;
     }
-  if ( error_code == MB_MEMORY_ALLOCATION_FAILED )
+  if ( error_code == moab::MB_MEMORY_ALLOCATION_FAILED )
     {
-      std::cerr << "ERROR: MB_MEMORY_ALLOCATION_FAILED" << std::endl;
+      std::cerr << "ERROR: moab::MB_MEMORY_ALLOCATION_FAILED" << std::endl;
     }
-  if ( error_code == MB_ENTITY_NOT_FOUND )
+  if ( error_code == moab::MB_ENTITY_NOT_FOUND )
     {
-      std::cerr << "ERROR: MB_ENTITY_NOT_FOUND" << std::endl;
+      std::cerr << "ERROR: moab::MB_ENTITY_NOT_FOUND" << std::endl;
     }
-  if ( error_code == MB_MULTIPLE_ENTITIES_FOUND )
+  if ( error_code == moab::MB_MULTIPLE_ENTITIES_FOUND )
     {
-      std::cerr << "ERROR: MB_MULTIPLE_ENTITIES_FOUND" << std::endl;
+      std::cerr << "ERROR: moab::MB_MULTIPLE_ENTITIES_FOUND" << std::endl;
     }
-  if ( error_code == MB_TAG_NOT_FOUND )
+  if ( error_code == moab::MB_TAG_NOT_FOUND )
     {
-      std::cerr << "ERROR: MB_TAG_NOT_FOUND" << std::endl;
+      std::cerr << "ERROR: moab::MB_TAG_NOT_FOUND" << std::endl;
     }
-  if ( error_code == MB_FILE_DOES_NOT_EXIST )
+  if ( error_code == moab::MB_FILE_DOES_NOT_EXIST )
     {
-      std::cerr << "ERROR: MB_FILE_DOES_NOT_EXIST" << std::endl;
+      std::cerr << "ERROR: moab::MB_FILE_DOES_NOT_EXIST" << std::endl;
     }    
-  if ( error_code == MB_FILE_WRITE_ERROR )
+  if ( error_code == moab::MB_FILE_WRITE_ERROR )
     {
-      std::cerr << "ERROR: MB_FILE_WRITE_ERROR" << std::endl;
+      std::cerr << "ERROR: moab::MB_FILE_WRITE_ERROR" << std::endl;
     }    
-  if ( error_code == MB_ALREADY_ALLOCATED )
+  if ( error_code == moab::MB_ALREADY_ALLOCATED )
     {
-      std::cerr << "ERROR: MB_ALREADY_ALLOCATED" << std::endl;
+      std::cerr << "ERROR: moab::MB_ALREADY_ALLOCATED" << std::endl;
     }    
-  if ( error_code == MB_VARIABLE_DATA_LENGTH )
+  if ( error_code == moab::MB_VARIABLE_DATA_LENGTH )
     {
-      std::cerr << "ERROR: MB_VARIABLE_DATA_LENGTH" << std::endl;
+      std::cerr << "ERROR: moab::MB_VARIABLE_DATA_LENGTH" << std::endl;
     }  
-  if ( error_code == MB_INVALID_SIZE )
+  if ( error_code == moab::MB_INVALID_SIZE )
     {
-      std::cerr << "ERROR: MB_INVALID_SIZE" << std::endl;
+      std::cerr << "ERROR: moab::MB_INVALID_SIZE" << std::endl;
     }  
-  if ( error_code == MB_UNSUPPORTED_OPERATION )
+  if ( error_code == moab::MB_UNSUPPORTED_OPERATION )
     {
-      std::cerr << "ERROR: MB_UNSUPPORTED_OPERATION" << std::endl;
+      std::cerr << "ERROR: moab::MB_UNSUPPORTED_OPERATION" << std::endl;
     }  
-  if ( error_code == MB_UNHANDLED_OPTION )
+  if ( error_code == moab::MB_UNHANDLED_OPTION )
     {
-      std::cerr << "ERROR: MB_UNHANDLED_OPTION" << std::endl;
+      std::cerr << "ERROR: moab::MB_UNHANDLED_OPTION" << std::endl;
     }  
-  if ( error_code == MB_FAILURE )
+  if ( error_code == moab::MB_FAILURE )
     {
-      std::cerr << "ERROR: MB_FAILURE" << std::endl;
+      std::cerr << "ERROR: moab::MB_FAILURE" << std::endl;
     }  
   return;
 }
@@ -95,57 +95,57 @@ void moab_printer(MBErrorCode error_code)
 
 
 
-  void print_vertex_cubit( const MBEntityHandle vertex ) {
+  void print_vertex_cubit( const moab::EntityHandle vertex ) {
 
-    MBErrorCode result;
+    moab::ErrorCode result;
     double coords[3];
     int n_precision = 20;
     result = MBI()->get_coords( &vertex, 1, coords );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     std::cout << "  create vertex " 
 	      << std::setprecision(n_precision)
 	      << coords[0] << " " << coords[1] << " " << coords[2]
 	      << std::endl;
   }
 
-  void print_vertex_coords( const MBEntityHandle vertex ) {
+  void print_vertex_coords( const moab::EntityHandle vertex ) {
 
-    MBErrorCode result;
+    moab::ErrorCode result;
     double coords[3];
     result = MBI()->get_coords( &vertex, 1, coords );
-    if(MB_SUCCESS!=result) std::cout << "vert=" << vertex << std::endl;
-    assert(MB_SUCCESS == result);
+    if(moab::MB_SUCCESS!=result) std::cout << "vert=" << vertex << std::endl;
+    assert(moab::MB_SUCCESS == result);
     std::cout << "    vertex " << vertex << " coords= (" 
 	      << coords[0] << "," << coords[1] << "," << coords[2] << ")" 
 	      << std::endl;
   }
 
-  void print_triangles( const MBRange tris ) {
-    for(MBRange::const_iterator i=tris.begin(); i!=tris.end(); i++) {
+  void print_triangles( const moab::Range tris ) {
+    for(moab::Range::const_iterator i=tris.begin(); i!=tris.end(); i++) {
       print_triangle( *i, false );
     }
   }
   // If the edges of the tri are ambiguous, do not print edges!
-  void print_triangle( const MBEntityHandle tri, bool print_edges ) {
-    MBErrorCode result;
+  void print_triangle( const moab::EntityHandle tri, bool print_edges ) {
+    moab::ErrorCode result;
     double area;
     result = triangle_area( tri, area );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     std::cout << "    triangle " << tri << " area=" << area << std::endl;
-    const MBEntityHandle *conn;
+    const moab::EntityHandle *conn;
     int n_verts;
     result = MBI()->get_connectivity( tri, conn, n_verts );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     assert(3 == n_verts);
     for(int i=0; i<3; i++) print_vertex_coords( conn[i] );
     
     if(print_edges) {
-      MBRange edges;
+      moab::Range edges;
       result = MBI()->get_adjacencies( &tri, 1, 1, true, edges );
-      if(MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
-      assert(MB_SUCCESS == result);
+      if(moab::MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
+      assert(moab::MB_SUCCESS == result);
       //std::cout << "      edges: ";
-      for(MBRange::iterator i=edges.begin(); i!=edges.end(); i++) {
+      for(moab::Range::iterator i=edges.begin(); i!=edges.end(); i++) {
         //std::cout << *i << " ";
         print_edge( *i );
       }
@@ -153,71 +153,71 @@ void moab_printer(MBErrorCode error_code)
     }
   }
 
-  void print_edge( const MBEntityHandle edge ) {
-    const MBEntityHandle *conn;
+  void print_edge( const moab::EntityHandle edge ) {
+    const moab::EntityHandle *conn;
     int n_verts;
     std::cout << "    edge " << edge << std::endl;
-    MBErrorCode result = MBI()->get_connectivity( edge, conn, n_verts );
-    assert(MB_SUCCESS == result);
+    moab::ErrorCode result = MBI()->get_connectivity( edge, conn, n_verts );
+    assert(moab::MB_SUCCESS == result);
     assert(2 == n_verts);
     print_vertex_coords( conn[0] );   
     print_vertex_coords( conn[1] ); 
 
-    MBRange tris;
+    moab::Range tris;
     result = MBI()->get_adjacencies( &edge, 1, 2, false, tris );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     std::cout << "     tris: ";
-    for(MBRange::iterator i=tris.begin(); i!=tris.end(); i++) {
+    for(moab::Range::iterator i=tris.begin(); i!=tris.end(); i++) {
       std::cout << *i << " ";
     }
     std::cout << std::endl; 
   }
 
-  void print_range( const MBRange range ) {
+  void print_range( const moab::Range range ) {
     std::cout << "print range:" << std::endl;
-    MBRange::iterator i;
+    moab::Range::iterator i;
     for(i=range.begin(); i!=range.end(); i++) {
       std::cout << "    " << *i << std::endl;
     }
   }
 
-  void print_range_of_edges( const MBRange range ) {
+  void print_range_of_edges( const moab::Range range ) {
     std::cout << "print range:" << std::endl;
-    MBRange::const_iterator i;
+    moab::Range::const_iterator i;
     for(i=range.begin(); i!=range.end(); i++) {
       print_edge( *i );
     }
   }
 
 
-  void print_vertex_count(const MBEntityHandle input_meshset) {
+  void print_vertex_count(const moab::EntityHandle input_meshset) {
   
     // get the range of facets of the surface meshset
-    MBErrorCode result;
-    MBRange vertices;
-    result = MBI()->get_entities_by_type(0, MBVERTEX, vertices);
-    assert( MB_SUCCESS == result );
+    moab::ErrorCode result;
+    moab::Range vertices;
+    result = MBI()->get_entities_by_type(0, moab::MBVERTEX, vertices);
+    assert( moab::MB_SUCCESS == result );
   
     std::cout<< "    " << vertices.size() << " vertices found." << std::endl;
   }
 
-  void print_arcs( const std::vector< std::vector<MBEntityHandle> > arcs ) {
+  void print_arcs( const std::vector< std::vector<moab::EntityHandle> > arcs ) {
     for(unsigned int i=0; i<arcs.size(); i++) {
       std::cout << "arc " << i << std::endl;
       print_loop( arcs[i] );
     }
   }
 
-  void print_arc_of_edges( const std::vector<MBEntityHandle> arc_of_edges ) {
+  void print_arc_of_edges( const std::vector<moab::EntityHandle> arc_of_edges ) {
   
-    MBErrorCode result;
-    std::vector<MBEntityHandle>::const_iterator i;
+    moab::ErrorCode result;
+    std::vector<moab::EntityHandle>::const_iterator i;
     double dist = 0;
     for( i=arc_of_edges.begin(); i!=arc_of_edges.end(); i++ ) {
       int n_verts;
-      const MBEntityHandle *conn;
+      const moab::EntityHandle *conn;
       result = MBI()->get_connectivity( *i, conn, n_verts ); 
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       assert( 2 == n_verts );
       dist += dist_between_verts( conn[0], conn[1] );
       print_vertex_coords( conn[0] );
@@ -226,11 +226,11 @@ void moab_printer(MBErrorCode error_code)
     std::cout << "  dist= " << dist << std::endl;
   }
 
-  void print_loop( const std::vector<MBEntityHandle> loop_of_verts ) {
+  void print_loop( const std::vector<moab::EntityHandle> loop_of_verts ) {
    
     std::cout << "  size=" << loop_of_verts.size() << std::endl;
     double dist = 0;
-    //std::vector<MBEntityHandle>::iterator i;
+    //std::vector<moab::EntityHandle>::iterator i;
     //for( i=loop_of_verts.begin(); i!=loop_of_verts.end(); i++ ) {
     for(unsigned int i=0; i<loop_of_verts.size(); i++) {
       print_vertex_coords( loop_of_verts[i] );
@@ -245,36 +245,36 @@ void moab_printer(MBErrorCode error_code)
 /// Return the closest vertex to the arc.
 /// For efficiency: only get_coords on the reference vertex once
 ///                 if specified, limit search length along curve
-MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
-                               const std::vector<MBEntityHandle> arc_of_verts,
+moab::ErrorCode find_closest_vert( const moab::EntityHandle reference_vert,
+                               const std::vector<moab::EntityHandle> arc_of_verts,
                                unsigned &position,
                                const double dist_limit ) {
-  MBErrorCode rval;
+  moab::ErrorCode rval;
   const bool debug = false;
   double min_dist_sqr = std::numeric_limits<double>::max();
-  MBCartVect ref_coords;
+  moab::CartVect ref_coords;
   rval = MBI()->get_coords( &reference_vert, 1, ref_coords.array() );
-  if(gen::error(MB_SUCCESS!=rval,"failed to get ref coords")) return rval;
+  if(gen::error(moab::MB_SUCCESS!=rval,"failed to get ref coords")) return rval;
   double length = 0;
-  MBCartVect prev_coords;
+  moab::CartVect prev_coords;
 
   for(unsigned i=0; i<arc_of_verts.size(); ++i) {
-    MBCartVect coords;
+    moab::CartVect coords;
     rval = MBI()->get_coords( &arc_of_verts[i], 1, coords.array() );
-    if(gen::error(MB_SUCCESS!=rval,"failed to get coords")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"failed to get coords")) return rval;
 
     // use dist_limit to exit early; avoid checking the entire arc
     if(0!=i) {
-      MBCartVect temp = prev_coords - coords;
+      moab::CartVect temp = prev_coords - coords;
       length += temp.length();
       if(length>dist_limit && debug) 
         std::cout << "length=" << length << " dist_limit=" << dist_limit << std::endl;
-      if(length > dist_limit) return MB_SUCCESS;
+      if(length > dist_limit) return moab::MB_SUCCESS;
     }
     prev_coords = coords;
 
     // get distance to ref_vert
-    MBCartVect temp = ref_coords - coords;
+    moab::CartVect temp = ref_coords - coords;
     double dist_sqr = temp.length_squared();
     if(dist_sqr < min_dist_sqr) {
       position = i;
@@ -283,7 +283,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     }
   }
  
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
 
 
@@ -292,13 +292,13 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   // the correct vert is not the closest. For example, iter_surf4010 the skin
   // loop has the same point in it twice, at two different locations (center of L).
   // This ensure that both are returned as candidates.
-  MBErrorCode find_closest_vert( const double tol,
-                                 const MBEntityHandle reference_vert,
-				 const std::vector<MBEntityHandle> loop_of_verts,
+  moab::ErrorCode find_closest_vert( const double tol,
+                                 const moab::EntityHandle reference_vert,
+				 const std::vector<moab::EntityHandle> loop_of_verts,
 				 std::vector<unsigned> &positions, 
 				 std::vector<double> &dists) {
 
-    MBErrorCode rval;
+    moab::ErrorCode rval;
     positions.clear();
     dists.clear();
     const double TOL_SQR = tol*tol;
@@ -307,7 +307,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     for(unsigned int i=0; i<loop_of_verts.size(); i++) {
 	double sqr_dist = std::numeric_limits<double>::max();
 	rval = squared_dist_between_verts(reference_vert, loop_of_verts[i], sqr_dist);
-        if(gen::error(MB_SUCCESS!=rval,"could not get dist")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"could not get dist")) return rval;
 	if(sqr_dist < sqr_min_dist) {
           if(sqr_dist >= TOL_SQR) {
             sqr_min_dist = sqr_dist;
@@ -326,24 +326,24 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     }
 
             
-   return MB_SUCCESS;
+   return moab::MB_SUCCESS;
   }
 
-  MBErrorCode merge_vertices( MBRange verts /* in */, const double tol /* in */ ) {
+  moab::ErrorCode merge_vertices( moab::Range verts /* in */, const double tol /* in */ ) {
 
-    MBErrorCode result;
+    moab::ErrorCode result;
     const double SQR_TOL = tol*tol;
     // Clean up the created tree, and track verts so that if merged away they are
     // removed from the tree.
-    MBAdaptiveKDTree kdtree(MBI()); //, true, 0, MESHSET_TRACK_OWNER);
+    moab::AdaptiveKDTree kdtree(MBI()); //, true, 0, moab::MESHSET_TRACK_OWNER);
     // initialize the KD Tree
-    MBEntityHandle root;
-    const char settings[]="MAX_PER_LEAF=6;MAX_DEPTH=50;SPLITS_PER_DIR=1;PLANE_SET=2;MESHSET_FLAGS=0x1;TAG_NAME=0";
+    moab::EntityHandle root;
+    const char settings[]="MAX_PER_LEAF=6;MAX_DEPTH=50;SPLITS_PER_DIR=1;PLANE_SET=2;moab::MESHSET_FLAGS=0x1;TAG_NAME=0";
     moab::FileOptions fileopts(settings);
 
 
     /* Old KDTree settings
-    MBAdaptiveKDTree::Settings settings;
+    moab::AdaptiveKDTree::Settings settings;
    
     // tells the tree to split leaves with more than 6 entities
     settings.maxEntPerLeaf = 6;
@@ -352,36 +352,36 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     // tells the tree how many candidate split planed to consider in each dimension
     settings.candidateSplitsPerDir = 1;
     // tells the tree to use the median vertex coordinate values to set planes
-    settings.candidatePlaneSet = MBAdaptiveKDTree::VERTEX_MEDIAN;
+    settings.candidatePlaneSet = moab::AdaptiveKDTree::VERTEX_MEDIAN;
    
     */
 
-    // builds the KD Tree, making the MBEntityHandle root the root of the tree
+    // builds the KD Tree, making the moab::EntityHandle root the root of the tree
     result = kdtree.build_tree( verts, &root, &fileopts);
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     // create tree iterator to loop over all verts in the tree
-    MBAdaptiveKDTreeIter tree_iter;
+    moab::AdaptiveKDTreeIter tree_iter;
     kdtree.get_tree_iterator( root, tree_iter );
  
     //for(unsigned int i=0; i<verts.size(); i++) {
-    for(MBRange::iterator i=verts.begin(); i!=verts.end(); ++i) {
+    for(moab::Range::iterator i=verts.begin(); i!=verts.end(); ++i) {
       double from_point[3];
-      //MBEntityHandle vert = *i;
+      //moab::EntityHandle vert = *i;
       result = MBI()->get_coords( &(*i), 1, from_point);
-      assert(MB_SUCCESS == result);
-      std::vector<MBEntityHandle> leaves_out;
+      assert(moab::MB_SUCCESS == result);
+      std::vector<moab::EntityHandle> leaves_out;
       result = kdtree.distance_search( from_point, tol, leaves_out, root);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       for(unsigned int j=0; j<leaves_out.size(); j++) {
-	std::vector<MBEntityHandle> leaf_verts;
-        result = MBI()->get_entities_by_type( leaves_out[j], MBVERTEX, leaf_verts);
-        assert(MB_SUCCESS == result);
+	std::vector<moab::EntityHandle> leaf_verts;
+        result = MBI()->get_entities_by_type( leaves_out[j], moab::MBVERTEX, leaf_verts);
+        assert(moab::MB_SUCCESS == result);
 	if(100 < leaf_verts.size()) std::cout << "*i=" << *i << " leaf_verts.size()=" << leaf_verts.size() << std::endl;
         for(unsigned int k=0; k<leaf_verts.size(); k++) {
 	  if( leaf_verts[k] == *i ) continue; 
 	  double sqr_dist;
 	  result = gen::squared_dist_between_verts( *i, leaf_verts[k], sqr_dist);
-	  assert(MB_SUCCESS == result);
+	  assert(moab::MB_SUCCESS == result);
 
 	  if(SQR_TOL >= sqr_dist) {
             //  std::cout << "merge_vertices: vert " << leaf_verts[k] << " merged to vert "
@@ -390,11 +390,11 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
             // The delete_vert is automatically remove from the tree because it
             // uses tracking meshsets. merge_verts checks for degenerate tris.
             // Update the list of leaf verts to prevent stale handles.
-	    std::vector<MBEntityHandle> temp_arc;
-            MBEntityHandle keep_vert   = *i;
-            MBEntityHandle delete_vert = leaf_verts[k];
+	    std::vector<moab::EntityHandle> temp_arc;
+            moab::EntityHandle keep_vert   = *i;
+            moab::EntityHandle delete_vert = leaf_verts[k];
 	    result = zip::merge_verts( keep_vert, delete_vert, leaf_verts, temp_arc );
-	    assert(MB_SUCCESS == result);
+	    assert(moab::MB_SUCCESS == result);
             // Erase delete_vert from verts
 	    // Iterator should remain valid because delete_vert > keep_vert handle.
 	    verts.erase( delete_vert );
@@ -402,52 +402,52 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 	}
       }
     }   
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode squared_dist_between_verts( const MBEntityHandle v0, 
-                                          const MBEntityHandle v1, 
+  moab::ErrorCode squared_dist_between_verts( const moab::EntityHandle v0, 
+                                          const moab::EntityHandle v1, 
                                           double &d) {
-    MBErrorCode result;
-    MBCartVect coords0, coords1;
+    moab::ErrorCode result;
+    moab::CartVect coords0, coords1;
     result = MBI()->get_coords( &v0, 1, coords0.array() );
-    if(MB_SUCCESS != result) {
+    if(moab::MB_SUCCESS != result) {
       std::cout << "dist_between_verts: get_coords on v0=" << v0 << " result=" 
                 << result << std::endl; 
       return result;
     }
     result = MBI()->get_coords( &v1, 1, coords1.array() );
-    if(MB_SUCCESS != result) {
+    if(moab::MB_SUCCESS != result) {
       std::cout << "dist_between_verts: get_coords on v1=" << v1 << " result=" 
                 << result << std::endl; 
       return result;
     }
-    const MBCartVect diff = coords0 - coords1;
+    const moab::CartVect diff = coords0 - coords1;
     d = diff.length_squared();
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  double dist_between_verts( const MBCartVect v0, const MBCartVect v1 ) {
-    MBCartVect v2 = v0 - v1;
+  double dist_between_verts( const moab::CartVect v0, const moab::CartVect v1 ) {
+    moab::CartVect v2 = v0 - v1;
     return v2.length();
   }
-  MBErrorCode dist_between_verts( const MBEntityHandle v0, const MBEntityHandle v1, double &d) {
-    MBErrorCode result;
-    MBCartVect coords0, coords1;
+  moab::ErrorCode dist_between_verts( const moab::EntityHandle v0, const moab::EntityHandle v1, double &d) {
+    moab::ErrorCode result;
+    moab::CartVect coords0, coords1;
     result = MBI()->get_coords( &v0, 1, coords0.array() );
-    if(MB_SUCCESS != result) {
+    if(moab::MB_SUCCESS != result) {
       std::cout << "dist_between_verts: get_coords on v0=" << v0 << " result=" 
                 << result << std::endl; 
       return result;
     }
     result = MBI()->get_coords( &v1, 1, coords1.array() );
-    if(MB_SUCCESS != result) {
+    if(moab::MB_SUCCESS != result) {
       std::cout << "dist_between_verts: get_coords on v1=" << v1 << " result=" 
                 << result << std::endl; 
       return result;
     }
     d = dist_between_verts( coords0, coords1 );
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
   double dist_between_verts( double coords0[], double coords1[] ) {
@@ -455,35 +455,35 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 		 (coords0[1]-coords1[1])*(coords0[1]-coords1[1]) +
 		 (coords0[2]-coords1[2])*(coords0[2]-coords1[2]) );
   }
-  double dist_between_verts( MBEntityHandle vert0, MBEntityHandle vert1 ) {
+  double dist_between_verts( moab::EntityHandle vert0, moab::EntityHandle vert1 ) {
     double coords0[3], coords1[3];
-    MBErrorCode result;
+    moab::ErrorCode result;
     result = MBI()->get_coords( &vert0, 1, coords0 );
-    if(MB_SUCCESS!=result) std::cout << "result=" << result << " vert=" 
+    if(moab::MB_SUCCESS!=result) std::cout << "result=" << result << " vert=" 
                                      << vert0 << std::endl;
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     result = MBI()->get_coords( &vert1, 1, coords1 );
-    if(MB_SUCCESS!=result) std::cout << "result=" << result << " vert=" 
+    if(moab::MB_SUCCESS!=result) std::cout << "result=" << result << " vert=" 
                                      << vert1 << std::endl;
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     return dist_between_verts( coords0, coords1 );
   }
 
-  // Return the length of the curve defined by MBEDGEs or ordered MBVERTEXs.
-  double length( std::vector<MBEntityHandle> edges ) {
+  // Return the length of the curve defined by moab::MBEDGEs or ordered moab::MBVERTEXs.
+  double length( std::vector<moab::EntityHandle> edges ) {
     if(edges.empty()) return 0;
 
-    MBErrorCode result;
-    std::vector<MBEntityHandle>::iterator i; 
+    moab::ErrorCode result;
+    std::vector<moab::EntityHandle>::iterator i; 
     double dist = 0;
-    MBEntityType type = MBI()->type_from_handle( edges[0] ); 
+    moab::EntityType type = MBI()->type_from_handle( edges[0] ); 
 
     // if vector has both edges and verts, only use edges
     // NOTE: The curve sets from ReadCGM do not contain duplicate endpoints for loops!
-    MBEntityType end_type = MBI()->type_from_handle( edges.back() );
+    moab::EntityType end_type = MBI()->type_from_handle( edges.back() );
     if(type != end_type) {
-      for(std::vector<MBEntityHandle>::iterator i=edges.begin(); i!=edges.end(); i++) {
-        if(MBVERTEX == MBI()->type_from_handle( *i )) {
+      for(std::vector<moab::EntityHandle>::iterator i=edges.begin(); i!=edges.end(); i++) {
+        if(moab::MBVERTEX == MBI()->type_from_handle( *i )) {
 	  i = edges.erase(i) - 1;
         }
       }
@@ -491,37 +491,37 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 
     // determine if vector defines an arc by edges of verts
     type = MBI()->type_from_handle( edges[0] ); 
-    if        (MBEDGE == type) {
+    if        (moab::MBEDGE == type) {
       if(edges.empty()) return 0.0; 
       for( i=edges.begin(); i!=edges.end(); i++ ) {
 	int n_verts;
-	const MBEntityHandle *conn;
+	const moab::EntityHandle *conn;
 	result = MBI()->get_connectivity( *i, conn, n_verts );
-	if( MB_SUCCESS!=result ) std::cout << "result=" << result << std::endl; 
-	assert(MB_SUCCESS == result);
+	if( moab::MB_SUCCESS!=result ) std::cout << "result=" << result << std::endl; 
+	assert(moab::MB_SUCCESS == result);
 	assert( 2 == n_verts );
         if(conn[0] == conn[1]) continue;
 	dist += dist_between_verts( conn[0], conn[1] );
 	//std::cout << "length: " << dist << std::endl;
       }
-    } else if (MBVERTEX == type) {
+    } else if (moab::MBVERTEX == type) {
       if(2 > edges.size()) return 0.0;
-      MBEntityHandle front_vert = edges.front();
+      moab::EntityHandle front_vert = edges.front();
       for( i=edges.begin()+1; i!=edges.end(); i++) {
 	dist += dist_between_verts( front_vert, *i );
 	front_vert = *i;
       }
-    } else return MB_FAILURE;
+    } else return moab::MB_FAILURE;
 
     return dist;
   }
 
   // Given a vertex and vector of edges, return the number of edges adjacent to the vertex.
-  unsigned int n_adj_edges( MBEntityHandle vert, MBRange edges ) {
-    MBErrorCode result;
-    MBRange adj_edges;
+  unsigned int n_adj_edges( moab::EntityHandle vert, moab::Range edges ) {
+    moab::ErrorCode result;
+    moab::Range adj_edges;
     result = MBI()->get_adjacencies( &vert, 1, 1, false, adj_edges );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     //adj_edges = adj_edges.intersect(edges);
     adj_edges = intersect( adj_edges, edges );
     return adj_edges.size();
@@ -530,14 +530,14 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 
 
   // Return true if the edges share a vertex. Does not check for coincident edges.
-  bool edges_adjacent( MBEntityHandle edge0, MBEntityHandle edge1 ) {
-    MBErrorCode result;
-    MBRange verts0, verts1;
+  bool edges_adjacent( moab::EntityHandle edge0, moab::EntityHandle edge1 ) {
+    moab::ErrorCode result;
+    moab::Range verts0, verts1;
     result = MBI()->get_adjacencies( &edge0, 1, 0, false, verts0 );
-    assert( MB_SUCCESS == result );
+    assert( moab::MB_SUCCESS == result );
     assert( 2 == verts0.size() );
     result = MBI()->get_adjacencies( &edge1, 1, 0, false, verts1 );
-    assert( MB_SUCCESS == result );
+    assert( moab::MB_SUCCESS == result );
     assert( 2 == verts1.size() );
     if      ( verts0.front() == verts1.front() ) return true;
     else if ( verts0.front() == verts1.back()  ) return true;
@@ -547,36 +547,36 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   }
 
   // get the direction unit vector from one vertex to another vertex
-  MBErrorCode get_direction( const MBEntityHandle from_vert, const MBEntityHandle to_vert,
-			     MBCartVect &dir ) {
+  moab::ErrorCode get_direction( const moab::EntityHandle from_vert, const moab::EntityHandle to_vert,
+			     moab::CartVect &dir ) {
     // double d[3];
-    MBErrorCode result;
-    MBCartVect coords0, coords1;
+    moab::ErrorCode result;
+    moab::CartVect coords0, coords1;
     result = MBI()->get_coords( &from_vert, 1, coords0.array() );
-    assert(MB_SUCCESS==result);
+    assert(moab::MB_SUCCESS==result);
     result = MBI()->get_coords( &to_vert, 1, coords1.array() );
-    assert(MB_SUCCESS==result);
+    assert(moab::MB_SUCCESS==result);
     dir = coords1 - coords0;
     if(0 == dir.length()) {
-      MBCartVect zero_vector( 0.0 );
+      moab::CartVect zero_vector( 0.0 );
       dir = zero_vector;
       std::cout << "direction vector has 0 magnitude" << std::endl;
-      return MB_SUCCESS;  
+      return moab::MB_SUCCESS;  
     }
     dir.normalize();
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }    
  
   // from http://www.topcoder.com/tc?module=Static&d1=tutorials&d2=geometry1
-  double edge_point_dist( const MBCartVect a, const MBCartVect b, const MBCartVect c ) {
-    MBCartVect ab, bc, ba, ac;
+  double edge_point_dist( const moab::CartVect a, const moab::CartVect b, const moab::CartVect c ) {
+    moab::CartVect ab, bc, ba, ac;
     ab = b - a;
     bc = c - b;
     ba = a - b;
     ac = c - a;
   
     // find the magnitude of the cross product and test the line
-    MBCartVect cross_product = ab*ac;
+    moab::CartVect cross_product = ab*ac;
     double dist = cross_product.length() / dist_between_verts(a,b);
  
     // test endpoint1
@@ -597,30 +597,30 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     //<< std::endl;      
     return fabs(dist);
   }
-  double edge_point_dist( const MBEntityHandle endpt0, const MBEntityHandle endpt1, 
-			  const MBEntityHandle pt ) {
-    MBErrorCode result;
-    MBCartVect a, b, c;
+  double edge_point_dist( const moab::EntityHandle endpt0, const moab::EntityHandle endpt1, 
+			  const moab::EntityHandle pt ) {
+    moab::ErrorCode result;
+    moab::CartVect a, b, c;
    result = MBI()->get_coords( &endpt0, 1, a.array() );
-    assert(MB_SUCCESS==result);
+    assert(moab::MB_SUCCESS==result);
     result = MBI()->get_coords( &endpt1, 1, b.array() );
-    assert(MB_SUCCESS==result);
+    assert(moab::MB_SUCCESS==result);
     result = MBI()->get_coords( &pt,     1, c.array() );
-    assert(MB_SUCCESS==result);
+    assert(moab::MB_SUCCESS==result);
     return edge_point_dist( a, b, c);
   }
-  double edge_point_dist( const MBEntityHandle edge, const MBEntityHandle pt ) {
-    MBErrorCode result;
-    const MBEntityHandle *conn;
+  double edge_point_dist( const moab::EntityHandle edge, const moab::EntityHandle pt ) {
+    moab::ErrorCode result;
+    const moab::EntityHandle *conn;
     int n_verts;     
     result = MBI()->get_connectivity( edge, conn, n_verts );
-    assert(MB_SUCCESS==result);
+    assert(moab::MB_SUCCESS==result);
     assert( 2 == n_verts );
     return edge_point_dist( conn[0], conn[1], pt );
   }
   /*
-  MBErrorCode  point_curve_min_dist( const std::vector<MBEntityHandle> curve, // of verts 
-				     const MBEntityHandle pt,
+  moab::ErrorCode  point_curve_min_dist( const std::vector<moab::EntityHandle> curve, // of verts 
+				     const moab::EntityHandle pt,
 				     double &min_dist,
                                      const double max_dist_along_curve ) { 
   
@@ -629,10 +629,10 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     bool last_edge = false;
   
     // it is a curve of verts or a curve of edges?
-    MBEntityType type = MBI()->type_from_handle( curve.front() );
-    std::vector<MBEntityHandle>::const_iterator i;
-    if(MBVERTEX == type) {
-      MBEntityHandle front_vert = curve.front();
+    moab::EntityType type = MBI()->type_from_handle( curve.front() );
+    std::vector<moab::EntityHandle>::const_iterator i;
+    if(moab::MBVERTEX == type) {
+      moab::EntityHandle front_vert = curve.front();
       for( i=curve.begin()+1; i!=curve.end(); i++) {
 	// if we are using verts, do not explicitly create the edge in MOAB
         cumulative_dist += gen::dist_between_verts( front_vert, *i );
@@ -647,105 +647,105 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 	  //print_vertex_coords( *i );
 	}
         // check one edge past the point after max_dist_along_curve
-        if(last_edge) return MB_SUCCESS;
+        if(last_edge) return moab::MB_SUCCESS;
         if(max_dist_along_curve<cumulative_dist) last_edge = true;
       
 	front_vert = *i;
       }
-    } //else if(MBEDGE == type) {        
+    } //else if(moab::MBEDGE == type) {        
       //for( i=curve.begin(); i!=curve.end(); i++) {
 //	double d = edge_point_dist( *i, pt );
 	//if(d < min_dist) min_dist = d;
       //}
      // } 
-       else return MB_FAILURE;
+       else return moab::MB_FAILURE;
     //std::cout << "point_curve_min_dist=" << min_dist << " curve.size()=" << curve.size() << std::endl;    
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode  point_curve_min_dist( const std::vector<MBEntityHandle> curve, // of verts 
-				     const MBEntityHandle pt,
+  moab::ErrorCode  point_curve_min_dist( const std::vector<moab::EntityHandle> curve, // of verts 
+				     const moab::EntityHandle pt,
 				     double &min_dist ) { 
     const double max_dist_along_curve = std::numeric_limits<double>::max();
     return point_curve_min_dist( curve, pt, min_dist, max_dist_along_curve ); 
   }
 */
-  double triangle_area( const MBCartVect a, const MBCartVect b, 
-                        const MBCartVect c) {
-    MBCartVect d = c - a;
-    MBCartVect e = c - b;
-    MBCartVect f = d*e;
+  double triangle_area( const moab::CartVect a, const moab::CartVect b, 
+                        const moab::CartVect c) {
+    moab::CartVect d = c - a;
+    moab::CartVect e = c - b;
+    moab::CartVect f = d*e;
     return 0.5*f.length();
   }
-  MBErrorCode triangle_area( const MBEntityHandle conn[], double &area ) {
-    MBCartVect coords[3];
-    MBErrorCode result = MBI()->get_coords( conn, 3, coords[0].array() );
-    assert(MB_SUCCESS == result);
+  moab::ErrorCode triangle_area( const moab::EntityHandle conn[], double &area ) {
+    moab::CartVect coords[3];
+    moab::ErrorCode result = MBI()->get_coords( conn, 3, coords[0].array() );
+    assert(moab::MB_SUCCESS == result);
     area = triangle_area( coords[0], coords[1], coords[2] );
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
-  MBErrorCode triangle_area( const MBEntityHandle tri, double &area ) {
-    MBErrorCode result;
-    const MBEntityHandle *conn;
+  moab::ErrorCode triangle_area( const moab::EntityHandle tri, double &area ) {
+    moab::ErrorCode result;
+    const moab::EntityHandle *conn;
     int n_verts;
     result = MBI()->get_connectivity( tri, conn, n_verts );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     assert(3 == n_verts);
     
     result = triangle_area( conn, area );
-    assert(MB_SUCCESS == result);
-    return MB_SUCCESS;
+    assert(moab::MB_SUCCESS == result);
+    return moab::MB_SUCCESS;
   }
-  double triangle_area( const MBRange tris ) {
+  double triangle_area( const moab::Range tris ) {
     double a, area = 0;
-    MBErrorCode result;
-    for(MBRange::iterator i=tris.begin(); i!=tris.end(); i++) {
+    moab::ErrorCode result;
+    for(moab::Range::iterator i=tris.begin(); i!=tris.end(); i++) {
       result = triangle_area( *i, a);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       area += a;
     }
     return area;
   }
 
-  bool triangle_degenerate( const MBEntityHandle tri ) {
-    MBErrorCode result;
-    const MBEntityHandle *conn;
+  bool triangle_degenerate( const moab::EntityHandle tri ) {
+    moab::ErrorCode result;
+    const moab::EntityHandle *conn;
     int n_verts;
     result = MBI()->get_connectivity( tri, conn, n_verts );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     assert(3 == n_verts);
     return triangle_degenerate( conn[0], conn[1], conn[2] );
   }
 
-  bool triangle_degenerate( const MBEntityHandle v0, const MBEntityHandle v1,
-			    const MBEntityHandle v2 ) { 
+  bool triangle_degenerate( const moab::EntityHandle v0, const moab::EntityHandle v1,
+			    const moab::EntityHandle v2 ) { 
     if(v0==v1 || v1==v2 || v2==v0) return true;
     return false;
   }
 
-  MBErrorCode triangle_normals( const MBRange tris, std::vector<MBCartVect> &normals ) {
-    MBErrorCode result;
+  moab::ErrorCode triangle_normals( const moab::Range tris, std::vector<moab::CartVect> &normals ) {
+    moab::ErrorCode result;
     normals.clear();
-    for(MBRange::const_iterator i=tris.begin(); i!=tris.end(); i++) {
-      MBCartVect normal;
+    for(moab::Range::const_iterator i=tris.begin(); i!=tris.end(); i++) {
+      moab::CartVect normal;
       result = triangle_normal( *i, normal );
-      assert(MB_SUCCESS==result || MB_ENTITY_NOT_FOUND==result);
+      assert(moab::MB_SUCCESS==result || moab::MB_ENTITY_NOT_FOUND==result);
       normals.push_back( normal );
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode triangle_normal( const MBEntityHandle tri, MBCartVect &normal) {
-    MBErrorCode result;
-    const MBEntityHandle *conn;
+  moab::ErrorCode triangle_normal( const moab::EntityHandle tri, moab::CartVect &normal) {
+    moab::ErrorCode result;
+    const moab::EntityHandle *conn;
     int n_verts;
     result = MBI()->get_connectivity( tri, conn, n_verts );
-    if(MB_ENTITY_NOT_FOUND == result) {
+    if(moab::MB_ENTITY_NOT_FOUND == result) {
       std::cout << "triangle_normal: triangle not found" << std::endl;
-      MBCartVect zero_vector( 0.0 );
+      moab::CartVect zero_vector( 0.0 );
       normal = zero_vector;
       return result;
-    }else if(MB_SUCCESS != result) {
+    }else if(moab::MB_SUCCESS != result) {
       return result;
     } else {
       assert(3 == n_verts);
@@ -753,41 +753,41 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     }
   }
 
-  MBErrorCode triangle_normal( const MBEntityHandle v0, const MBEntityHandle v1,
-			       const MBEntityHandle v2, MBCartVect &normal ) {
+  moab::ErrorCode triangle_normal( const moab::EntityHandle v0, const moab::EntityHandle v1,
+			       const moab::EntityHandle v2, moab::CartVect &normal ) {
 
     // if tri is degenerate return 0,0,0
     if( triangle_degenerate(v0, v1, v2) ) {
-      MBCartVect zero_vector( 0.0 );
+      moab::CartVect zero_vector( 0.0 );
       normal = zero_vector;
       std::cout << "  normal=" << normal << std::endl;
-      return MB_SUCCESS;
+      return moab::MB_SUCCESS;
     }
 
-    MBEntityHandle conn[3];
+    moab::EntityHandle conn[3];
     conn[0] = v0;
     conn[1] = v1;
     conn[2] = v2;
-    MBErrorCode result;
-    MBCartVect coords[3];
+    moab::ErrorCode result;
+    moab::CartVect coords[3];
     result = MBI()->get_coords( conn, 3, coords[0].array() );
-    assert(MB_SUCCESS == result); 
+    assert(moab::MB_SUCCESS == result); 
     return triangle_normal( coords[0], coords[1], coords[2], normal );
   }
 
-  MBErrorCode triangle_normal( const MBCartVect coords0, const MBCartVect coords1,
-			       const MBCartVect coords2, MBCartVect &normal ) {
-    MBCartVect edge0, edge1;
+  moab::ErrorCode triangle_normal( const moab::CartVect coords0, const moab::CartVect coords1,
+			       const moab::CartVect coords2, moab::CartVect &normal ) {
+    moab::CartVect edge0, edge1;
     edge0 = coords1-coords0;
     edge1 = coords2-coords0;
     normal = edge0*edge1;
 
     // do not normalize if magnitude is zero (avoid nans)
-    if(0 == normal.length()) return MB_SUCCESS;
+    if(0 == normal.length()) return moab::MB_SUCCESS;
 
     normal.normalize();
     //if(debug) std::cout << "  normal=" << normal << std::endl;
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
     
 
@@ -795,102 +795,102 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   // Distance between a point and line. The line is defined by two verts.
   // We are using a line and not a line segment!
   // http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
-  MBErrorCode line_point_dist( const MBEntityHandle line_pt1, const MBEntityHandle line_pt2, 
-			       const MBEntityHandle pt0, double &dist ) {
-    MBErrorCode result;
-    MBCartVect x0, x1, x2;
+  moab::ErrorCode line_point_dist( const moab::EntityHandle line_pt1, const moab::EntityHandle line_pt2, 
+			       const moab::EntityHandle pt0, double &dist ) {
+    moab::ErrorCode result;
+    moab::CartVect x0, x1, x2;
     result = MBI()->get_coords( &line_pt1, 1, x1.array() );
-    assert(MB_SUCCESS == result); 
+    assert(moab::MB_SUCCESS == result); 
     result = MBI()->get_coords( &line_pt2, 1, x2.array() );
-    assert(MB_SUCCESS == result); 
+    assert(moab::MB_SUCCESS == result); 
     result = MBI()->get_coords( &pt0, 1, x0.array() );
-    assert(MB_SUCCESS == result); 
+    assert(moab::MB_SUCCESS == result); 
 
     dist = ( ((x0-x1)*(x0-x2)).length() ) / ( (x2-x1).length() );
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
   // Project the point onto the line. Not the line segment!
-  MBErrorCode point_line_projection( const MBEntityHandle line_pt1,
-				     const MBEntityHandle line_pt2,
-				     const MBEntityHandle pt0 ) {
-    MBCartVect projected_coords;
+  moab::ErrorCode point_line_projection( const moab::EntityHandle line_pt1,
+				     const moab::EntityHandle line_pt2,
+				     const moab::EntityHandle pt0 ) {
+    moab::CartVect projected_coords;
     double parameter;
-    MBErrorCode result = point_line_projection( line_pt1, line_pt2, 
+    moab::ErrorCode result = point_line_projection( line_pt1, line_pt2, 
 						pt0, projected_coords,
 						parameter );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     result = MBI()->set_coords( &pt0, 1, projected_coords.array() );   
-    assert(MB_SUCCESS == result);
-    return MB_SUCCESS;
+    assert(moab::MB_SUCCESS == result);
+    return moab::MB_SUCCESS;
   }    
-  MBErrorCode point_line_projection( const MBEntityHandle line_pt1,
-				     const MBEntityHandle line_pt2,
-				     const MBEntityHandle pt0,
-				     MBCartVect &projected_coords,
+  moab::ErrorCode point_line_projection( const moab::EntityHandle line_pt1,
+				     const moab::EntityHandle line_pt2,
+				     const moab::EntityHandle pt0,
+				     moab::CartVect &projected_coords,
 				     double &parameter  ) {
 
-    MBErrorCode result;
-    MBCartVect coords[3];   
+    moab::ErrorCode result;
+    moab::CartVect coords[3];   
     result = MBI()->get_coords( &line_pt1, 1, coords[1].array() );
-    assert(MB_SUCCESS == result);                                            
+    assert(moab::MB_SUCCESS == result);                                            
     result = MBI()->get_coords( &line_pt2, 1, coords[2].array() );           
-    assert(MB_SUCCESS == result);                                     
+    assert(moab::MB_SUCCESS == result);                                     
     result = MBI()->get_coords( &pt0, 1, coords[0].array() );          
-    assert(MB_SUCCESS == result);                                           
+    assert(moab::MB_SUCCESS == result);                                           
 
     // project the t_joint between the endpts                  
     // http://en.wikipedia.org/wiki/Vector_projection           
-    MBCartVect a = coords[0] - coords[1];                 
-    MBCartVect b = coords[2] - coords[1]; 
+    moab::CartVect a = coords[0] - coords[1];                 
+    moab::CartVect b = coords[2] - coords[1]; 
     parameter    = (a%b)/(b%b);
-    MBCartVect c = parameter*b;                    
+    moab::CartVect c = parameter*b;                    
     projected_coords = c     + coords[1];      
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
-  MBErrorCode point_line_projection( const MBEntityHandle line_pt1,
-				     const MBEntityHandle line_pt2,
-				     const MBEntityHandle pt0,
+  moab::ErrorCode point_line_projection( const moab::EntityHandle line_pt1,
+				     const moab::EntityHandle line_pt2,
+				     const moab::EntityHandle pt0,
 				     double &dist_along_edge  ) {
 
-    MBErrorCode result;
-    MBCartVect coords[3];   
+    moab::ErrorCode result;
+    moab::CartVect coords[3];   
     result = MBI()->get_coords( &line_pt1, 1, coords[1].array() );
-    assert(MB_SUCCESS == result);                                            
+    assert(moab::MB_SUCCESS == result);                                            
     result = MBI()->get_coords( &line_pt2, 1, coords[2].array() );           
-    assert(MB_SUCCESS == result);                                     
+    assert(moab::MB_SUCCESS == result);                                     
     result = MBI()->get_coords( &pt0, 1, coords[0].array() );          
-    assert(MB_SUCCESS == result);                                           
+    assert(moab::MB_SUCCESS == result);                                           
 
     // project the t_joint between the endpts                  
     // http://en.wikipedia.org/wiki/Vector_projection           
-    MBCartVect a = coords[0] - coords[1];                 
-    MBCartVect b = coords[2] - coords[1]; 
+    moab::CartVect a = coords[0] - coords[1];                 
+    moab::CartVect b = coords[2] - coords[1]; 
     dist_along_edge = a%b / b.length();      
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
   
 
-  double area2( const MBEntityHandle pt_a, const MBEntityHandle pt_b,
-                const MBEntityHandle pt_c, const MBCartVect plane_normal ) {
+  double area2( const moab::EntityHandle pt_a, const moab::EntityHandle pt_b,
+                const moab::EntityHandle pt_c, const moab::CartVect plane_normal ) {
     //std::cout << "area2: a=" << pt_a << " b=" << pt_b << " c=" << pt_c << std::endl;
-    MBErrorCode result;
-    MBCartVect a, b, c;
+    moab::ErrorCode result;
+    moab::CartVect a, b, c;
     result = MBI()->get_coords( &pt_a, 1, a.array() );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     result = MBI()->get_coords( &pt_b, 1, b.array() );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     result = MBI()->get_coords( &pt_c, 1, c.array() );
-    assert(MB_SUCCESS == result);
-    MBCartVect d = b - a;
-    MBCartVect e = c - a;
+    assert(moab::MB_SUCCESS == result);
+    moab::CartVect d = b - a;
+    moab::CartVect e = c - a;
     // project onto a plane defined by the plane's normal vector
     return (d*e)%plane_normal;
   }
 
   // Is point c to the left of line ab?
-  bool left( const MBEntityHandle a, const MBEntityHandle b,
-	     const MBEntityHandle c, const MBCartVect n ) {
+  bool left( const moab::EntityHandle a, const moab::EntityHandle b,
+	     const moab::EntityHandle c, const moab::CartVect n ) {
     double area_2 = area2(a,b,c,n);
     //std::cout << "left: a=" << a << " b=" << b << " c=" << c
     //          << " area2=" << area_2 << std::endl;
@@ -899,8 +899,8 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   } 
 
   // Is point c to the left of line ab or collinear?
-  bool left_on( const MBEntityHandle a, const MBEntityHandle b,
-		const MBEntityHandle c, const MBCartVect n ) {
+  bool left_on( const moab::EntityHandle a, const moab::EntityHandle b,
+		const moab::EntityHandle c, const moab::CartVect n ) {
     double area_2 = area2(a,b,c,n);
     //std::cout << "left_on: a=" << a << " b=" << b << " c=" << c
     //          << " area2=" << area_2 << std::endl;
@@ -909,8 +909,8 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   } 
 
   // Are pts a,b,c collinear?
-  bool collinear( const MBEntityHandle a, const MBEntityHandle b,
-		  const MBEntityHandle c, const MBCartVect n ) {
+  bool collinear( const moab::EntityHandle a, const moab::EntityHandle b,
+		  const moab::EntityHandle c, const moab::CartVect n ) {
     double area_2 = area2(a,b,c,n);
     //std::cout << "collinear: a=" << a << " b=" << b << " c=" << c
     //          << " area2=" << area_2 << std::endl;
@@ -923,9 +923,9 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     return (x || y) && !(x && y);
   }
 
-  bool intersect_prop( const MBEntityHandle a, const MBEntityHandle b,
-                       const MBEntityHandle c, const MBEntityHandle d,
-                       const MBCartVect n ) {
+  bool intersect_prop( const moab::EntityHandle a, const moab::EntityHandle b,
+                       const moab::EntityHandle c, const moab::EntityHandle d,
+                       const moab::CartVect n ) {
     if( collinear(a,b,c,n) ||
         collinear(a,b,d,n) ||
         collinear(c,d,a,n) ||
@@ -937,18 +937,18 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     }
   }
       
-  bool between( const MBEntityHandle pt_a, const MBEntityHandle pt_b, 
-                const MBEntityHandle pt_c, const MBCartVect n) {
+  bool between( const moab::EntityHandle pt_a, const moab::EntityHandle pt_b, 
+                const moab::EntityHandle pt_c, const moab::CartVect n) {
     if( !collinear(pt_a,pt_b,pt_c,n) ) return false;
 
-    MBErrorCode result;
-    MBCartVect a, b, c;
+    moab::ErrorCode result;
+    moab::CartVect a, b, c;
     result = MBI()->get_coords( &pt_a, 1, a.array() );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     result = MBI()->get_coords( &pt_b, 1, b.array() );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     result = MBI()->get_coords( &pt_c, 1, c.array() );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
 
     // if ab not vertical, check betweenness on x; else on y.
     if(a[0] != b[0]) {
@@ -960,9 +960,9 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     }
   }
 
-  bool intersect( const MBEntityHandle a, const MBEntityHandle b,
-		  const MBEntityHandle c, const MBEntityHandle d,
-                  const MBCartVect n ) {
+  bool intersect( const moab::EntityHandle a, const moab::EntityHandle b,
+		  const moab::EntityHandle c, const moab::EntityHandle d,
+                  const moab::CartVect n ) {
     if(intersect_prop(a,b,c,d,n)) return true;
     else if( between(a,b,c,n) ||
              between(a,b,d,n) ||
@@ -972,12 +972,12 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   }
 
   // verts is an ordered polygon of verts
-  bool diagonalie( const MBEntityHandle a, const MBEntityHandle b,
-                   const MBCartVect n, 
-		   const std::vector<MBEntityHandle> verts ) {
+  bool diagonalie( const moab::EntityHandle a, const moab::EntityHandle b,
+                   const moab::CartVect n, 
+		   const std::vector<moab::EntityHandle> verts ) {
     for(unsigned int i=0; i<verts.size(); i++) {
-      MBEntityHandle c = verts[i];
-      MBEntityHandle c1;
+      moab::EntityHandle c = verts[i];
+      moab::EntityHandle c1;
       if(verts.size()-1 == i) c1 = verts[0];
       else                    c1 = verts[i+1];
 
@@ -996,12 +996,12 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   }
 
   // verts is an ordered polygon of verts
-  bool in_cone( const MBEntityHandle a, const MBEntityHandle b,
-                const MBCartVect n,
-                const std::vector<MBEntityHandle> verts ) { 
-    std::vector<MBEntityHandle>::const_iterator a_iter;
+  bool in_cone( const moab::EntityHandle a, const moab::EntityHandle b,
+                const moab::CartVect n,
+                const std::vector<moab::EntityHandle> verts ) { 
+    std::vector<moab::EntityHandle>::const_iterator a_iter;
     a_iter = find( verts.begin(), verts.end(), a );
-    MBEntityHandle a0, a1;
+    moab::EntityHandle a0, a1;
     // a0 is before a
     if(verts.begin() == a_iter) a0 = verts[verts.size()-1];
     else a0 = *(a_iter-1);
@@ -1018,9 +1018,9 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     else return !(left_on(a,b,a1,n) && left_on(b,a,a0,n));
   }
 
-  bool diagonal( const MBEntityHandle a, const MBEntityHandle b,
-                 const MBCartVect n,
-                 const std::vector<MBEntityHandle> verts ) {
+  bool diagonal( const moab::EntityHandle a, const moab::EntityHandle b,
+                 const moab::CartVect n,
+                 const std::vector<moab::EntityHandle> verts ) {
     bool result = in_cone(a,b,n,verts) && in_cone(b,a,n,verts) && diagonalie(a,b,n,verts);
     //std::cout << "diagonal a=" << a << " b=" << b << " result="
     //          << result << std::endl;
@@ -1029,12 +1029,12 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 
 
   // Determine if each vertex is an ear. Input an ordered polygon of verts.
-  MBErrorCode ear_init( const std::vector<MBEntityHandle> verts,
-                        const MBCartVect n, // plane normal vector
+  moab::ErrorCode ear_init( const std::vector<moab::EntityHandle> verts,
+                        const moab::CartVect n, // plane normal vector
                         std::vector<bool> &is_ear ) {
-    if(verts.size() != is_ear.size()) return MB_FAILURE;
+    if(verts.size() != is_ear.size()) return moab::MB_FAILURE;
     for(unsigned int i=0; i<verts.size(); i++) {
-      MBEntityHandle prev, next;
+      moab::EntityHandle prev, next;
       if(0 == i) prev = verts.back();
       else prev = verts[i-1];
       if(verts.size()-1 == i) next = verts[0];
@@ -1042,16 +1042,16 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
       is_ear[i] = diagonal(prev,next,n,verts);
       //std::cout << "is_ear[" << i << "]=" << is_ear[i] << std::endl;
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
 
 
   // Input an ordered polygon of verts and a normal vector of the plane
   // that the polygon is mostly in. The vector is required for orientation.
-  MBErrorCode ear_clip_polygon( std::vector<MBEntityHandle> verts,
-                                MBCartVect n, 
-				MBRange &new_tris ) {
+  moab::ErrorCode ear_clip_polygon( std::vector<moab::EntityHandle> verts,
+                                moab::CartVect n, 
+				moab::Range &new_tris ) {
 
     // initialize the status of ears
     //std::cout << "begin ear clipping----------------------" << std::endl;
@@ -1060,10 +1060,10 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     //}
 
     //print_loop( verts );
-    MBErrorCode result;
+    moab::ErrorCode result;
     std::vector<bool> is_ear( verts.size() );
     result = ear_init( verts, n, is_ear );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
  
     // if the polygon intersects itself the algorithm will not stop
     int counter = 0; 
@@ -1072,7 +1072,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     while(3 < verts.size()) {
       for(unsigned int i=0; i<verts.size(); i++) {
         if(is_ear[i]) {
-          MBEntityHandle v0, v1, v2, v3, v4;
+          moab::EntityHandle v0, v1, v2, v3, v4;
           if(0 == i)      v0 = verts[verts.size()-2];
           else if(1 == i) v0 = verts[verts.size()-1];
           else            v0 = verts[i-2]; 
@@ -1089,10 +1089,10 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
           //print_vertex_coords( v1 ); 
           //print_vertex_coords( v2 ); 
           //print_vertex_coords( v3 );
-          MBEntityHandle new_tri; 
-          MBEntityHandle conn[3] = {v1,v2,v3};
-          result = MBI()->create_element( MBTRI, conn, 3, new_tri );
-          assert(MB_SUCCESS == result);
+          moab::EntityHandle new_tri; 
+          moab::EntityHandle conn[3] = {v1,v2,v3};
+          result = MBI()->create_element( moab::MBTRI, conn, 3, new_tri );
+          assert(moab::MB_SUCCESS == result);
           new_tris.insert( new_tri );
 
           // update ear status
@@ -1115,9 +1115,9 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
       if(counter > n_initial_verts) {
 	//std::cout << "ear_clip_polygon: no ears found" << std::endl;
         result = MBI()->delete_entities( new_tris );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         new_tris.clear();
-        return MB_FAILURE;
+        return moab::MB_FAILURE;
       }
       counter++;
     } 
@@ -1125,109 +1125,109 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     //print_vertex_coords( verts[0] ); 
     //print_vertex_coords( verts[1] ); 
     //print_vertex_coords( verts[2] );
-    MBEntityHandle new_tri; 
-    MBEntityHandle conn[3] = {verts[0],verts[1],verts[2]};
-    result = MBI()->create_element( MBTRI, conn, 3, new_tri );
-    assert(MB_SUCCESS == result);
+    moab::EntityHandle new_tri; 
+    moab::EntityHandle conn[3] = {verts[0],verts[1],verts[2]};
+    result = MBI()->create_element( moab::MBTRI, conn, 3, new_tri );
+    assert(moab::MB_SUCCESS == result);
     new_tris.insert( new_tri );
     
-    return MB_SUCCESS; 
+    return moab::MB_SUCCESS; 
   }
 
-  int geom_id_by_handle( const MBEntityHandle set ) {
-    MBErrorCode result;
-    MBTag id_tag;
-    //result = MBI()->tag_create( GLOBAL_ID_TAG_NAME, sizeof(int), MB_TAG_DENSE,
-    //                                MB_TYPE_INTEGER, id_tag, 0, true );           
-    result = MBI()->tag_get_handle( GLOBAL_ID_TAG_NAME, 1, MB_TYPE_INTEGER,id_tag,moab::MB_TAG_DENSE);
-    assert(MB_SUCCESS==result || MB_ALREADY_ALLOCATED==result);                       
+  int geom_id_by_handle( const moab::EntityHandle set ) {
+    moab::ErrorCode result;
+    moab::Tag id_tag;
+    //result = MBI()->tag_create( GLOBAL_ID_TAG_NAME, sizeof(int), moab::MB_TAG_DENSE,
+    //                                moab::MB_TYPE_INTEGER, id_tag, 0, true );           
+    result = MBI()->tag_get_handle( GLOBAL_ID_TAG_NAME, 1, moab::MB_TYPE_INTEGER,id_tag,moab::MB_TAG_DENSE);
+    assert(moab::MB_SUCCESS==result || moab::MB_ALREADY_ALLOCATED==result);                       
     int id;
     result = MBI()->tag_get_data( id_tag, &set, 1, &id );                  
-    //assert(MB_SUCCESS == result);                           
+    //assert(moab::MB_SUCCESS == result);                           
     return id;
   }
   
-  MBErrorCode save_normals( MBRange tris, MBTag normal_tag ) {
-    std::vector<MBCartVect> normals(tris.size());
-    MBErrorCode result;
+  moab::ErrorCode save_normals( moab::Range tris, moab::Tag normal_tag ) {
+    std::vector<moab::CartVect> normals(tris.size());
+    moab::ErrorCode result;
     result = triangle_normals( tris, normals );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
 
     result = MBI()->tag_set_data(normal_tag, tris, &normals[0]);
-    assert(MB_SUCCESS == result);
-    return MB_SUCCESS;
+    assert(moab::MB_SUCCESS == result);
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode flip(const MBEntityHandle tri, const MBEntityHandle vert0, 
-		   const MBEntityHandle vert2, const MBEntityHandle surf_set) {
+  moab::ErrorCode flip(const moab::EntityHandle tri, const moab::EntityHandle vert0, 
+		   const moab::EntityHandle vert2, const moab::EntityHandle surf_set) {
 
     // get the triangles in the surface. The tri and adj_tri must be in the surface.
-    MBRange surf_tris;
-    MBEntityHandle result = MBI()->get_entities_by_type( surf_set, MBTRI, surf_tris);
-    assert(MB_SUCCESS == result);
+    moab::Range surf_tris;
+    moab::EntityHandle result = MBI()->get_entities_by_type( surf_set, moab::MBTRI, surf_tris);
+    assert(moab::MB_SUCCESS == result);
 
     // get the triangle across the edge that will be flipped
-    MBRange adj_tri;
-    MBEntityHandle edge[2] = {vert0, vert2};
+    moab::Range adj_tri;
+    moab::EntityHandle edge[2] = {vert0, vert2};
     result = MBI()->get_adjacencies( edge, 2, 2, false, adj_tri );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     adj_tri = intersect(adj_tri, surf_tris);
     assert(2 == adj_tri.size());
     adj_tri.erase( tri );
     print_triangle( adj_tri.front(), false );
     //result = MBI()->list_entity( adj_tri.front() );
-    //assert(MB_SUCCESS == result);
+    //assert(moab::MB_SUCCESS == result);
 
     // get the remaining tri vert
-    MBRange tri_verts;
+    moab::Range tri_verts;
     result = MBI()->get_adjacencies( &tri, 1, 0, false, tri_verts );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     assert(3 == tri_verts.size());
     tri_verts.erase(vert0);
     tri_verts.erase(vert2);
     assert(1 == tri_verts.size());
-    MBEntityHandle vert1 = tri_verts.front();
+    moab::EntityHandle vert1 = tri_verts.front();
 
     // get the remaining adj_tri vert
-    MBRange adj_tri_verts;
+    moab::Range adj_tri_verts;
     result = MBI()->get_adjacencies( &adj_tri.front(), 1, 0, false, adj_tri_verts );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     assert(3 == adj_tri_verts.size());
     adj_tri_verts.erase(vert0);
     adj_tri_verts.erase(vert2);
     assert(1 == adj_tri_verts.size());
-    MBEntityHandle vert3 = adj_tri_verts.front();
+    moab::EntityHandle vert3 = adj_tri_verts.front();
 
     // original tri_conn    = {vert0, vert1, vert2}
     // original adj_tri_conn= {vert2, vert3, vert0}
  
     // set the new connectivity
-    MBEntityHandle tri_conn[3] = {vert0, vert1, vert3};
+    moab::EntityHandle tri_conn[3] = {vert0, vert1, vert3};
     result = MBI()->set_connectivity( tri, tri_conn, 3 );
-    assert(MB_SUCCESS == result);
-    MBEntityHandle adj_tri_conn[3] = {vert1, vert2, vert3};
+    assert(moab::MB_SUCCESS == result);
+    moab::EntityHandle adj_tri_conn[3] = {vert1, vert2, vert3};
     result = MBI()->set_connectivity( adj_tri.front(), adj_tri_conn, 3 );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     print_triangle( tri, false );
     print_triangle( adj_tri.front(), false );
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode ordered_verts_from_ordered_edges( const std::vector<MBEntityHandle> ordered_edges,
-                                                std::vector<MBEntityHandle> &ordered_verts ) {
-    MBErrorCode result;
+  moab::ErrorCode ordered_verts_from_ordered_edges( const std::vector<moab::EntityHandle> ordered_edges,
+                                                std::vector<moab::EntityHandle> &ordered_verts ) {
+    moab::ErrorCode result;
     ordered_verts.clear();
     ordered_verts.reserve(ordered_edges.size()+1);
 
     // Save the back of the previous edge to check for continuity.
-    MBEntityHandle previous_back_vert;
+    moab::EntityHandle previous_back_vert;
     
-    for(std::vector<MBEntityHandle>::const_iterator i=ordered_edges.begin(); 
+    for(std::vector<moab::EntityHandle>::const_iterator i=ordered_edges.begin(); 
         i!=ordered_edges.end(); i++) {
-      const MBEntityHandle *conn;
+      const moab::EntityHandle *conn;
       int n_verts;
       result = MBI()->get_connectivity( *i, conn, n_verts);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       assert(2 == n_verts);
       if(ordered_edges.begin() == i) {
         ordered_verts.push_back(conn[0]);
@@ -1237,33 +1237,33 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
       ordered_verts.push_back(conn[1]);
       previous_back_vert = conn[1];
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
   /* Find the distance between two arcs. Assume that their endpoints are somewhat
      close together. */
-  MBErrorCode dist_between_arcs( bool debug,
-                                 const std::vector<MBEntityHandle> arc0,
-                                 const std::vector<MBEntityHandle> arc1,
+  moab::ErrorCode dist_between_arcs( bool debug,
+                                 const std::vector<moab::EntityHandle> arc0,
+                                 const std::vector<moab::EntityHandle> arc1,
                                  double &dist ) {
     dist = 0;
 
     // Special Case: arcs have no verts.
     if( arc0.empty() || arc1.empty() ) {
       std::cout << "arc has no vertices" << std::endl;
-      return MB_FAILURE;
+      return moab::MB_FAILURE;
     }
 
     //print_loop(arc0);
     //print_loop(arc1);
 
     // for simplicity, put arcs into the same structure
-    std::vector<MBEntityHandle> arcs[2] = {arc0, arc1};
+    std::vector<moab::EntityHandle> arcs[2] = {arc0, arc1};
 
     // Special Case: Remove duplicate vert handles
     for(unsigned int i=0; i<2; ++i) {
       if( 2>arcs[i].size() ) continue;
-      for(std::vector<MBEntityHandle>::iterator j=arcs[i].begin()+1; j!=arcs[i].end(); ++j) {
+      for(std::vector<moab::EntityHandle>::iterator j=arcs[i].begin()+1; j!=arcs[i].end(); ++j) {
         if(*j == *(j-1)) {
 	  if(debug) {
             gen::print_loop( arcs[i] );
@@ -1275,12 +1275,12 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     }
     
     // get the coords in one call per arc. For speed, do not ask MOAB again for coords.
-    MBErrorCode result;
-    std::vector<MBCartVect> coords[2];
+    moab::ErrorCode result;
+    std::vector<moab::CartVect> coords[2];
     for(unsigned int i=0; i<2; i++) {
       coords[i].resize( arcs[i].size() );
       result = MBI()->get_coords( &arcs[i][0], arcs[i].size(), coords[i][0].array());
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
     }
 
     // Special case: arc has 1 vert or a length of zero
@@ -1303,7 +1303,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
       // Both are point arcs
       if(1==arcs[other_arc_index].size()) {
         dist = dist_between_verts( arcs[point_arc_index].front(), arcs[other_arc_index].front());
-        return MB_SUCCESS;
+        return moab::MB_SUCCESS;
 	// The other arc has more than one point
       } else {
         double area = 0.0;
@@ -1313,7 +1313,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
                                       coords[point_arc_index].front() ));
         }
         dist = area / gen::length(arcs[other_arc_index]);
-        return MB_SUCCESS;
+        return moab::MB_SUCCESS;
       }
     }
 
@@ -1365,7 +1365,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
         if(params[i][j] > mgd_params[j]) {
           double ratio = (mgd_params[j]-params[i][j-1]) / (params[i][j]-params[i][j-1]);
 	  //std::cout << "j=" << j << " ratio=" << ratio << std::endl;
-          MBCartVect pt = coords[i][j-1] + ratio*(coords[i][j]-coords[i][j-1]);
+          moab::CartVect pt = coords[i][j-1] + ratio*(coords[i][j]-coords[i][j-1]);
 	  coords[i].insert( coords[i].begin()+j, pt);
           params[i].insert( params[i].begin()+j, mgd_params[j]); 
         }
@@ -1395,7 +1395,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     // Divide the area by the average length to get the average distance between arcs.
     dist = fabs(2*area / (arc_len[0] + arc_len[1] ));
     //std::cout << "dist_between_arcs=" << dist << std::endl;
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
 
@@ -1418,34 +1418,34 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   // in the MOAB instance. Otherwise checking to see if an edge exists before
   // creating a new one if very slow. This is partly the reason that MBSkinner is
   // very slow.
-  MBErrorCode find_skin( MBRange tris, const int dim, 
- //                         std::vector<std::vector<MBEntityHandle> > &skin_edges, 
-                         MBRange &skin_edges,                         
+  moab::ErrorCode find_skin( moab::Range tris, const int dim, 
+ //                         std::vector<std::vector<moab::EntityHandle> > &skin_edges, 
+                         moab::Range &skin_edges,                         
                          const bool temp_bool ) {    
 
     const bool local_debug = false;
     //MBSkinner tool(MBI());
-    //MBRange skin_verts;
+    //moab::Range skin_verts;
     //return tool.find_skin( tris, dim, skin_edges, temp_bool );
     //return tool.find_skin_vertices( tris, skin_verts, &skin_edges, true );
   
-    if(1 != dim) return MB_NOT_IMPLEMENTED;
-    if(MBTRI != MBI()->type_from_handle(tris.front())) return MB_NOT_IMPLEMENTED;
+    if(1 != dim) return moab::MB_NOT_IMPLEMENTED;
+    if(moab::MBTRI != MBI()->type_from_handle(tris.front())) return moab::MB_NOT_IMPLEMENTED;
 
     skin_edges.clear();
-    if(tris.empty()) return MB_ENTITY_NOT_FOUND;
+    if(tris.empty()) return moab::MB_ENTITY_NOT_FOUND;
 
     // This implementation gets some of its speed due to not checking for edges
-    MBErrorCode result;
+    moab::ErrorCode result;
     int n_edges;
-    result = MBI()->get_number_entities_by_type( 0, MBEDGE, n_edges );
-    assert(MB_SUCCESS == result);
+    result = MBI()->get_number_entities_by_type( 0, moab::MBEDGE, n_edges );
+    assert(moab::MB_SUCCESS == result);
     if(0 != n_edges) {
-      MBRange temp_edges;
-      result = MBI()->get_entities_by_type( 0, MBEDGE, temp_edges);
-      assert(MB_SUCCESS == result);
+      moab::Range temp_edges;
+      result = MBI()->get_entities_by_type( 0, moab::MBEDGE, temp_edges);
+      assert(moab::MB_SUCCESS == result);
       result = MBI()->list_entities( temp_edges );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
     }      
     assert(0 == n_edges);
 
@@ -1453,10 +1453,10 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     edge *edges = new edge[3*tris.size()];
     int n_verts;
     int ii = 0;
-    for(MBRange::iterator i=tris.begin(); i!=tris.end(); i++) {
-      const MBEntityHandle *conn;
+    for(moab::Range::iterator i=tris.begin(); i!=tris.end(); i++) {
+      const moab::EntityHandle *conn;
       result = MBI()->get_connectivity( *i, conn, n_verts );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       assert(3 == n_verts);
       // shouldn't be degenerate
       assert(conn[0] != conn[1]);
@@ -1475,7 +1475,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     // Change the first handle to be lowest
     for(unsigned int i=0; i<3*tris.size(); ++i) {
       if(edges[i].v0 > edges[i].v1) {
-        MBEntityHandle temp = edges[i].v0;
+        moab::EntityHandle temp = edges[i].v0;
         edges[i].v0 = edges[i].v1;
         edges[i].v1 = temp;
       }
@@ -1490,10 +1490,10 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
       // If the last edge has not been paired, create it. This avoids overrunning
       // the edges array with i+1.
       if(3*tris.size()-1 == i) {
-        const MBEntityHandle conn[2] = {edges[i].v0, edges[i].v1};
-        MBEntityHandle edge;
-        result = MBI()->create_element( MBEDGE, conn, 2, edge );
-        assert(MB_SUCCESS == result);
+        const moab::EntityHandle conn[2] = {edges[i].v0, edges[i].v1};
+        moab::EntityHandle edge;
+        result = MBI()->create_element( moab::MBEDGE, conn, 2, edge );
+        assert(moab::MB_SUCCESS == result);
         skin_edges.insert(edge);
     
       // If a match exists, skip ahead
@@ -1512,46 +1512,46 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
         }
 	// otherwise a skin edge has been found
       } else {
-        const MBEntityHandle conn[2] = {edges[i].v0, edges[i].v1};
-        MBEntityHandle edge;
-        result = MBI()->create_element( MBEDGE, conn, 2, edge );
-        if(gen::error(MB_SUCCESS!=result, "could not create edge element")) return result;
+        const moab::EntityHandle conn[2] = {edges[i].v0, edges[i].v1};
+        moab::EntityHandle edge;
+        result = MBI()->create_element( moab::MBEDGE, conn, 2, edge );
+        if(gen::error(moab::MB_SUCCESS!=result, "could not create edge element")) return result;
         skin_edges.insert( edge );
       } 
     }
     delete[] edges;
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
-  /*  MBErrorCode find_skin( MBRange tris, const int dim, MBRange &skin_edges, const bool temp ) {
-    std::vector<std::vector<MBEntityHandle> > skin_edges_vctr;
-    MBErrorCode result = find_skin( tris, dim, skin_edges_vctr, temp );
-    assert(MB_SUCCESS == result);
-    for(std::vector<std::vector<MBEntityHandle> >::const_iterator i=skin_edges_vctr.begin(); 
+  /*  moab::ErrorCode find_skin( moab::Range tris, const int dim, moab::Range &skin_edges, const bool temp ) {
+    std::vector<std::vector<moab::EntityHandle> > skin_edges_vctr;
+    moab::ErrorCode result = find_skin( tris, dim, skin_edges_vctr, temp );
+    assert(moab::MB_SUCCESS == result);
+    for(std::vector<std::vector<moab::EntityHandle> >::const_iterator i=skin_edges_vctr.begin(); 
         i!=skin_edges_vctr.end(); i++) {
-      MBEntityHandle edge;
-      result = MBI()->create_element( MBEDGE, &(*i)[0], 2, edge );
-      if(MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
-      assert(MB_SUCCESS == result);
+      moab::EntityHandle edge;
+      result = MBI()->create_element( moab::MBEDGE, &(*i)[0], 2, edge );
+      if(moab::MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
+      assert(moab::MB_SUCCESS == result);
       skin_edges.insert( edge );
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
     }*/
 
 // calculate volume of polyhedron
 // Copied from DagMC, without index_by_handle. The dagmc function will
 // segfault if build_indices is not first called. For sealing there is
 // no need to build_indices.
-  MBErrorCode measure_volume( const MBEntityHandle volume, double& result, bool debug, bool verbose )
+  moab::ErrorCode measure_volume( const moab::EntityHandle volume, double& result, bool debug, bool verbose )
 {
-  MBErrorCode rval;
-  std::vector<MBEntityHandle> surfaces, surf_volumes;
+  moab::ErrorCode rval;
+  std::vector<moab::EntityHandle> surfaces, surf_volumes;
   result = 0.0;
   
  
 
   // get surfaces from volume
   rval = MBI()->get_child_meshsets( volume, surfaces );
-  if (MB_SUCCESS != rval)
+  if (moab::MB_SUCCESS != rval)
     {
       return rval;
     }
@@ -1561,7 +1561,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   std::vector<int> senses( surfaces.size() );
 
 
-  if (rval != MB_SUCCESS)
+  if (rval != moab::MB_SUCCESS)
     {
       std::cout << "Could not measure volume" << std::endl;
       std::cout << "This can happen for 2 reasons, there are no volumes" << std::endl;
@@ -1575,7 +1575,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 
   if(debug) std::cout << "in measure_volume 2" << std::endl;
 
-  if (MB_SUCCESS != rval) 
+  if (moab::MB_SUCCESS != rval) 
     {
       std::cerr << "ERROR: Surface-Volume relative sense not available. "
                 << "Cannot calculate volume." << std::endl;
@@ -1590,20 +1590,20 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 	continue;
     
       // get triangles in surface
-      MBRange triangles;
+      moab::Range triangles;
       rval = MBI()->get_entities_by_dimension( surfaces[i], 2, triangles );
-      if (MB_SUCCESS != rval) 
+      if (moab::MB_SUCCESS != rval) 
 	{
 	  return rval;
 	}
-    if (!triangles.all_of_type(MBTRI)) 
+    if (!triangles.all_of_type(moab::MBTRI)) 
       {
 	std::cout << "WARNING: Surface " << geom_id_by_handle(surfaces[i])
 		  << " contains non-triangle elements. Volume calculation may be incorrect."
 		  << std::endl;
 	triangles.clear();
-	rval = MBI()->get_entities_by_type( surfaces[i], MBTRI, triangles );
-	if (MB_SUCCESS != rval) 
+	rval = MBI()->get_entities_by_type( surfaces[i], moab::MBTRI, triangles );
+	if (moab::MB_SUCCESS != rval) 
 	  {
 	    return rval;
 	  }
@@ -1611,15 +1611,15 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
     
       // calculate signed volume beneath surface (x 6.0)
     double surf_sum = 0.0;
-    const MBEntityHandle *conn;
+    const moab::EntityHandle *conn;
     int len;
-    MBCartVect coords[3];
-    for (MBRange::iterator j = triangles.begin(); j != triangles.end(); ++j) {
+    moab::CartVect coords[3];
+    for (moab::Range::iterator j = triangles.begin(); j != triangles.end(); ++j) {
       rval = MBI()->get_connectivity( *j, conn, len, true );
-      if (MB_SUCCESS != rval) return rval;
+      if (moab::MB_SUCCESS != rval) return rval;
       assert(3 == len);
       rval = MBI()->get_coords( conn, 3, coords[0].array() );
-      if (MB_SUCCESS != rval) return rval;
+      if (moab::MB_SUCCESS != rval) return rval;
     
       coords[1] -= coords[0];
       coords[2] -= coords[0];
@@ -1630,81 +1630,81 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
   
   result /= 6.0;
   if(debug)  std::cout << result << std::endl;
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
 
   /// Calculate the signed volumes beneath the surface (x 6.0). Use the triangle's
   ///   cannonical sense. Do not take sense tags into account. Code taken from 
   ///   DagMC::measure_volume. 
-  MBErrorCode get_signed_volume( const MBEntityHandle surf_set, double &signed_volume) {
-    MBErrorCode rval;                                     
-    MBRange tris;                          
-    rval = MBI()->get_entities_by_type( surf_set, MBTRI, tris );
-    if(MB_SUCCESS != rval) return rval;       
+  moab::ErrorCode get_signed_volume( const moab::EntityHandle surf_set, double &signed_volume) {
+    moab::ErrorCode rval;                                     
+    moab::Range tris;                          
+    rval = MBI()->get_entities_by_type( surf_set, moab::MBTRI, tris );
+    if(moab::MB_SUCCESS != rval) return rval;       
     signed_volume = 0.0;
-    const MBEntityHandle *conn;                                  
+    const moab::EntityHandle *conn;                                  
     int len;
-    MBCartVect coords[3];                                              
-    for (MBRange::iterator j = tris.begin(); j != tris.end(); ++j) {         
+    moab::CartVect coords[3];                                              
+    for (moab::Range::iterator j = tris.begin(); j != tris.end(); ++j) {         
       rval = MBI()->get_connectivity( *j, conn, len, true );           
-      if (MB_SUCCESS != rval) return rval;            
+      if (moab::MB_SUCCESS != rval) return rval;            
       assert(3 == len);                    
       rval = MBI()->get_coords( conn, 3, coords[0].array() );              
-      if (MB_SUCCESS != rval) return rval;         
+      if (moab::MB_SUCCESS != rval) return rval;         
                             
       coords[1] -= coords[0];                              
       coords[2] -= coords[0];                     
       signed_volume += (coords[0] % (coords[1] * coords[2]));       
     }                                     
-    return MB_SUCCESS;                              
+    return moab::MB_SUCCESS;                              
   }                 
 
-MBErrorCode measure( const MBEntityHandle set, const MBTag geom_tag, double &size, bool debug,  bool verbose ) {
-    MBErrorCode result;
+moab::ErrorCode measure( const moab::EntityHandle set, const moab::Tag geom_tag, double &size, bool debug,  bool verbose ) {
+    moab::ErrorCode result;
     int dim;
     result = MBI()->tag_get_data( geom_tag, &set, 1, &dim );                  
-    assert(MB_SUCCESS == result);                           
+    assert(moab::MB_SUCCESS == result);                           
     if(0 == dim) {
       std::cout << "measure: cannot measure vertex" << std::endl;
-      return MB_FAILURE;
+      return moab::MB_FAILURE;
 
     } else if(1 == dim) {
-      std::vector<MBEntityHandle> vctr;
+      std::vector<moab::EntityHandle> vctr;
       result = arc::get_meshset( set, vctr );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       size = length( vctr );
 
     } else if(2 == dim) {
-      MBRange tris;
-      result = MBI()->get_entities_by_type( set, MBTRI, tris );
-      assert(MB_SUCCESS == result);
+      moab::Range tris;
+      result = MBI()->get_entities_by_type( set, moab::MBTRI, tris );
+      assert(moab::MB_SUCCESS == result);
       size = triangle_area( tris );
 
     } else if(3 == dim) {
       
       result = measure_volume( set, size, debug, verbose );
       
-      if(MB_SUCCESS != result) {
+      if(moab::MB_SUCCESS != result) {
         std::cout << "result=" << result << " vol_id=" 
                   << gen::geom_id_by_handle(set) << std::endl;
       }
     } else {
       std::cout << "measure: incorrect dimension" << std::endl;
-      return MB_FAILURE;
+      return moab::MB_FAILURE;
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
   // From CGMA/builds/dbg/include/CubitDefines
   /// gets the surface sense with respect to the curve and returns the value to sense
-  MBErrorCode get_curve_surf_sense( const MBEntityHandle surf_set, const MBEntityHandle curve_set,
+  moab::ErrorCode get_curve_surf_sense( const moab::EntityHandle surf_set, const moab::EntityHandle curve_set,
                                     int &sense, bool debug ) {
-    std::vector<MBEntityHandle> surfs;
+    std::vector<moab::EntityHandle> surfs;
     std::vector<int> senses;
-    MBErrorCode rval;
+    moab::ErrorCode rval;
     moab::GeomTopoTool gt( MBI(), false);
     rval = gt.get_senses( curve_set, surfs, senses );
-    if(gen::error(MB_SUCCESS!=rval,"failed to get_senses")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"failed to get_senses")) return rval;
     
     unsigned counter = 0;
     int edim;
@@ -1732,34 +1732,34 @@ MBErrorCode measure( const MBEntityHandle set, const MBTag geom_tag, double &siz
     }
    }
     // special case: parent surface does not exist
-    if(gen::error(0==counter,"failed to find a surf in sense list")) return MB_FAILURE;
+    if(gen::error(0==counter,"failed to find a surf in sense list")) return moab::MB_FAILURE;
 
    
 
      // special case: ambiguous
     if(1<counter) sense = SENSE_UNKNOWN;
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode surface_sense( MBEntityHandle volume, 
+  moab::ErrorCode surface_sense( moab::EntityHandle volume, 
                            int num_surfaces,
-                           const MBEntityHandle* surfaces,
+                           const moab::EntityHandle* surfaces,
                            int* senses_out )
   {
-    std::vector<MBEntityHandle> surf_volumes( 2*num_surfaces );
-    MBTag senseTag = get_tag( "GEOM_SENSE_2", 2, MB_TAG_SPARSE, MB_TYPE_HANDLE, NULL, false );
-    MBErrorCode rval = MBI()->tag_get_data( senseTag , surfaces, num_surfaces, &surf_volumes[0] );
-    if (MB_SUCCESS != rval)
+    std::vector<moab::EntityHandle> surf_volumes( 2*num_surfaces );
+    moab::Tag senseTag = get_tag( "GEOM_SENSE_2", 2, moab::MB_TAG_SPARSE, moab::MB_TYPE_HANDLE, NULL, false );
+    moab::ErrorCode rval = MBI()->tag_get_data( senseTag , surfaces, num_surfaces, &surf_volumes[0] );
+    if (moab::MB_SUCCESS != rval)
       {
 	return rval;
       }
   
-    const MBEntityHandle* end = surfaces + num_surfaces;
-    std::vector<MBEntityHandle>::const_iterator surf_vols = surf_volumes.begin();
+    const moab::EntityHandle* end = surfaces + num_surfaces;
+    std::vector<moab::EntityHandle>::const_iterator surf_vols = surf_volumes.begin();
     while (surfaces != end) 
       {
-	MBEntityHandle forward = *surf_vols; ++surf_vols;
-	MBEntityHandle reverse = *surf_vols; ++surf_vols;
+	moab::EntityHandle forward = *surf_vols; ++surf_vols;
+	moab::EntityHandle reverse = *surf_vols; ++surf_vols;
 	if (volume == forward) 
 	  {
 	    *senses_out = (volume != reverse); // zero if both, otherwise 1
@@ -1770,26 +1770,26 @@ MBErrorCode measure( const MBEntityHandle set, const MBTag geom_tag, double &siz
 	  }
 	else 
 	  {
-	    return MB_ENTITY_NOT_FOUND;
+	    return moab::MB_ENTITY_NOT_FOUND;
 	  }
     
 	++surfaces;
 	++senses_out;
       }
   
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
   /// get sense of surface(s) wrt volume
-  MBErrorCode surface_sense( MBEntityHandle volume, 
-                             MBEntityHandle surface,
+  moab::ErrorCode surface_sense( moab::EntityHandle volume, 
+                             moab::EntityHandle surface,
                              int& sense_out )
   {
     // get sense of surfaces wrt volumes
-    MBEntityHandle surf_volumes[2];
-    MBTag senseTag = get_tag( "GEOM_SENSE_2", 2, MB_TAG_SPARSE, MB_TYPE_HANDLE, NULL, false );
-    MBErrorCode rval = MBI()->tag_get_data( senseTag , &surface, 1, surf_volumes );
-    if (MB_SUCCESS != rval) 
+    moab::EntityHandle surf_volumes[2];
+    moab::Tag senseTag = get_tag( "GEOM_SENSE_2", 2, moab::MB_TAG_SPARSE, moab::MB_TYPE_HANDLE, NULL, false );
+    moab::ErrorCode rval = MBI()->tag_get_data( senseTag , &surface, 1, surf_volumes );
+    if (moab::MB_SUCCESS != rval) 
       {
 	return rval;
       }
@@ -1804,24 +1804,24 @@ MBErrorCode measure( const MBEntityHandle set, const MBTag geom_tag, double &siz
       }
     else
       {
-	return MB_ENTITY_NOT_FOUND;
+	return moab::MB_ENTITY_NOT_FOUND;
       }
   
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
  }
 
- MBTag get_tag( const char* name, int size, MBTagType store,
-		     MBDataType type, const void* def_value,
+ moab::Tag get_tag( const char* name, int size, moab::TagType store,
+		     moab::DataType type, const void* def_value,
 		     bool create_if_missing)
  {
-   MBTag retval = 0;
+   moab::Tag retval = 0;
    unsigned flags = store|moab::MB_TAG_CREAT;
    if (!create_if_missing)
      {
        flags |= moab::MB_TAG_EXCL;
      }
-   MBErrorCode result = MBI()->tag_get_handle(name, size, type, retval, flags, def_value);
-   if (create_if_missing && MB_SUCCESS != result)
+   moab::ErrorCode result = MBI()->tag_get_handle(name, size, type, retval, flags, def_value);
+   if (create_if_missing && moab::MB_SUCCESS != result)
      {
        std::cerr << "Couldn't find nor create tag named " << name << std::endl;
      }
@@ -1831,56 +1831,56 @@ MBErrorCode measure( const MBEntityHandle set, const MBTag geom_tag, double &siz
 
 
 
-MBErrorCode delete_surface( MBEntityHandle surf, MBTag geom_tag, MBRange tris, int id, bool debug, bool verbose ) {
+moab::ErrorCode delete_surface( moab::EntityHandle surf, moab::Tag geom_tag, moab::Range tris, int id, bool debug, bool verbose ) {
 
-  MBErrorCode result;
+  moab::ErrorCode result;
 
   //measure area of the surface  
         double area;
         result = gen::measure( surf, geom_tag, area, debug, verbose );
-        if(gen::error(MB_SUCCESS!=result,"could not measure area")) return result;
-        assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not measure area")) return result;
+        assert(moab::MB_SUCCESS == result);
 
   //remove triagngles from the surface
         result = MBI()->remove_entities( surf, tris);                          
-        if(gen::error(MB_SUCCESS!=result,"could not remove tris")) return result;
-	assert(MB_SUCCESS == result);       
+        if(gen::error(moab::MB_SUCCESS!=result,"could not remove tris")) return result;
+	assert(moab::MB_SUCCESS == result);       
   //print information about the deleted surface if requested by the user
         if(debug) std::cout << "  deleted surface " << id
                   << ", area=" << area << " cm^2, n_facets=" << tris.size() << std::endl;
 
   // delete triangles from mesh data
 	result = MBI()->delete_entities( tris );                               
-        if(gen::error(MB_SUCCESS!=result,"could not delete tris")) return result;
-	assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not delete tris")) return result;
+	assert(moab::MB_SUCCESS == result);
 
   //remove the sense data for the surface from its child curves
         result = remove_surf_sense_data( surf, debug);
-        if(gen::error(MB_SUCCESS!=result, "could not remove surface's sense data")) return result;
+        if(gen::error(moab::MB_SUCCESS!=result, "could not remove surface's sense data")) return result;
 
   //remove the surface set itself
         result = MBI()->delete_entities( &(surf), 1);
-        if(gen::error(MB_SUCCESS!=result,"could not delete surface set")) return result;
-        assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not delete surface set")) return result;
+        assert(moab::MB_SUCCESS == result);
 
 
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
  }
 
  /// removes sense data from all curves associated with the surface given to the function
 
-MBErrorCode remove_surf_sense_data(MBEntityHandle del_surf, bool debug) {
+moab::ErrorCode remove_surf_sense_data(moab::EntityHandle del_surf, bool debug) {
  
-  MBErrorCode result;
+  moab::ErrorCode result;
   moab::GeomTopoTool gt(MBI(), false);
     int edim = gt.dimension(del_surf);
 
-    if(gen::error(edim!=2,"could not remove sense data: entity is of the wrong dimension")) return MB_FAILURE;
+    if(gen::error(edim!=2,"could not remove sense data: entity is of the wrong dimension")) return moab::MB_FAILURE;
 
  // get the curves of the surface
-        MBRange del_surf_curves;
+        moab::Range del_surf_curves;
         result = MBI() -> get_child_meshsets( del_surf, del_surf_curves);
-        if(gen::error(MB_SUCCESS!=result,"could not get the curves of the surface to delete")) return result;
+        if(gen::error(moab::MB_SUCCESS!=result,"could not get the curves of the surface to delete")) return result;
         if (debug) std::cout << "got the curves" << std::endl;
        
   
@@ -1896,25 +1896,25 @@ MBErrorCode remove_surf_sense_data(MBEntityHandle del_surf, bool debug) {
         //get the sense data for each curve
 
         //get sense_tag handles from MOAB
-        MBTag senseEnts, senseSenses;
-        unsigned flags = MB_TAG_SPARSE;
+        moab::Tag senseEnts, senseSenses;
+        unsigned flags = moab::MB_TAG_SPARSE;
      
         //get tag for the entities with sense data associated with a given moab entity
-        result = MBI()-> tag_get_handle(GEOM_SENSE_N_ENTS_TAG_NAME, 0, MB_TYPE_HANDLE, senseEnts, flags);
-        if(gen::error(MB_SUCCESS!=result, "could not get senseEnts tag")) return result;
+        result = MBI()-> tag_get_handle(GEOM_SENSE_N_ENTS_TAG_NAME, 0, moab::MB_TYPE_HANDLE, senseEnts, flags);
+        if(gen::error(moab::MB_SUCCESS!=result, "could not get senseEnts tag")) return result;
         
         //get tag for the sense data associated with the senseEnts entities for a given moab entity
-        result = MBI()-> tag_get_handle(GEOM_SENSE_N_SENSES_TAG_NAME, 0, MB_TYPE_INTEGER, senseSenses, flags);
-        if(gen::error(MB_SUCCESS!=result,"could not get senseSenses tag")) return result;
+        result = MBI()-> tag_get_handle(GEOM_SENSE_N_SENSES_TAG_NAME, 0, moab::MB_TYPE_INTEGER, senseSenses, flags);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not get senseSenses tag")) return result;
         
         //initialize vectors for entities and sense data
-        std::vector<MBEntityHandle> surfaces;
+        std::vector<moab::EntityHandle> surfaces;
         std::vector<int> senses;
-        for(MBRange::iterator i=del_surf_curves.begin(); i!=del_surf_curves.end(); i++ ) 
+        for(moab::Range::iterator i=del_surf_curves.begin(); i!=del_surf_curves.end(); i++ ) 
         {
        
         result = gt.get_senses(*i, surfaces, senses);
-        if(gen::error(MB_SUCCESS!=result, "could not get the senses for the del_surf_curve")) return result;
+        if(gen::error(moab::MB_SUCCESS!=result, "could not get the senses for the del_surf_curve")) return result;
           // if the surface to be deleted (del_surf) exists in the sense data (which it should), then remove it
           for(unsigned int index = 0; index < senses.size() ; index++)
           {
@@ -1927,47 +1927,47 @@ MBErrorCode remove_surf_sense_data(MBEntityHandle del_surf, bool debug) {
           }
           //remove existing sense entity data for the curve
           result= MBI()-> tag_delete_data( senseEnts, &*i, 1);
-          if(gen::error(MB_SUCCESS!=result, "could not delete sense entity data")) return result;
+          if(gen::error(moab::MB_SUCCESS!=result, "could not delete sense entity data")) return result;
        
           //remove existing sense data for the curve
           result = MBI()-> tag_delete_data(senseSenses, &*i, 1);
-          if(gen::error(MB_SUCCESS!=result, "could not delete sense data")) return result;
+          if(gen::error(moab::MB_SUCCESS!=result, "could not delete sense data")) return result;
 
           //reset the sense data for each curve 
           result = gt.set_senses( *i, surfaces, senses);
-          if(gen::error(MB_SUCCESS!=result, "could not update sense data for surface deletion")) return result;
+          if(gen::error(moab::MB_SUCCESS!=result, "could not update sense data for surface deletion")) return result;
 
         }
 
- return MB_SUCCESS;
+ return moab::MB_SUCCESS;
  } 
 
 /// combines the senses of any curves tagged as merged in the vector curves
- MBErrorCode combine_merged_curve_senses( std::vector<MBEntityHandle> &curves, MBTag merge_tag, bool debug) {
+ moab::ErrorCode combine_merged_curve_senses( std::vector<moab::EntityHandle> &curves, moab::Tag merge_tag, bool debug) {
 
-  MBErrorCode result; 
+  moab::ErrorCode result; 
   
-  for(std::vector<MBEntityHandle>::iterator j=curves.begin(); j!=curves.end(); j++) {
+  for(std::vector<moab::EntityHandle>::iterator j=curves.begin(); j!=curves.end(); j++) {
 
 
-  MBEntityHandle merged_curve;
+  moab::EntityHandle merged_curve;
   result = MBI() -> tag_get_data( merge_tag, &(*j), 1, &merged_curve);
-  if(gen::error(MB_SUCCESS!=result && MB_TAG_NOT_FOUND!=result, "could not get the merge_tag data of the curve")) return result;
+  if(gen::error(moab::MB_SUCCESS!=result && moab::MB_TAG_NOT_FOUND!=result, "could not get the merge_tag data of the curve")) return result;
 
-  if(MB_SUCCESS==result) { // we have found a merged curve pairing
+  if(moab::MB_SUCCESS==result) { // we have found a merged curve pairing
     // add the senses from the curve_to_delete to curve_to keep
     // create vectors for the senses and surfaces of each curve
-    std::vector<MBEntityHandle> curve_to_keep_surfs, curve_to_delete_surfs, combined_surfs;
+    std::vector<moab::EntityHandle> curve_to_keep_surfs, curve_to_delete_surfs, combined_surfs;
     std::vector<int> curve_to_keep_senses, curve_to_delete_senses, combined_senses;
 
     //initialize GeomTopoTool.cpp instance in MOAB
     moab::GeomTopoTool gt(MBI(), false);
     // get senses of the iterator curve and place them in the curve_to_delete vectors
     result = gt.get_senses( *j, curve_to_delete_surfs, curve_to_delete_senses);
-    if(gen::error(MB_SUCCESS!=result, "could not get the surfs/senses of the curve to delete")) return result;
+    if(gen::error(moab::MB_SUCCESS!=result, "could not get the surfs/senses of the curve to delete")) return result;
     // get surfaces/senses of the merged_curve and place them in the curve_to_keep vectors
     result = gt.get_senses( merged_curve, curve_to_keep_surfs, curve_to_keep_senses);
-    if(gen::error(MB_SUCCESS!=result, "could not get the surfs/senses of the curve to delete")) return result;
+    if(gen::error(moab::MB_SUCCESS!=result, "could not get the surfs/senses of the curve to delete")) return result;
     
     if(debug){
           std::cout << "curve to keep id = " << gen::geom_id_by_handle(merged_curve) << std::endl;
@@ -2009,7 +2009,7 @@ MBErrorCode remove_surf_sense_data(MBEntityHandle del_surf, bool debug) {
     } // end debug st. 
 
     result = gt.set_senses(merged_curve, combined_surfs, combined_senses);
-    if(gen::error(MB_SUCCESS!=result && MB_MULTIPLE_ENTITIES_FOUND!=result,"failed to set senses: "));
+    if(gen::error(moab::MB_SUCCESS!=result && moab::MB_MULTIPLE_ENTITIES_FOUND!=result,"failed to set senses: "));
 
 
     
@@ -2024,86 +2024,86 @@ MBErrorCode remove_surf_sense_data(MBEntityHandle del_surf, bool debug) {
 
 
 
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
   }
 
-MBErrorCode get_sealing_mesh_tags( double &facet_tol,
+moab::ErrorCode get_sealing_mesh_tags( double &facet_tol,
                            double &sme_resabs_tol,
-                           MBTag &geom_tag, 
-                           MBTag &id_tag, 
-                           MBTag &normal_tag, 
-                           MBTag &merge_tag, 
-                           MBTag &faceting_tol_tag, 
-                           MBTag &geometry_resabs_tag, 
-                           MBTag &size_tag, 
-                           MBTag &orig_curve_tag) {
+                           moab::Tag &geom_tag, 
+                           moab::Tag &id_tag, 
+                           moab::Tag &normal_tag, 
+                           moab::Tag &merge_tag, 
+                           moab::Tag &faceting_tol_tag, 
+                           moab::Tag &geometry_resabs_tag, 
+                           moab::Tag &size_tag, 
+                           moab::Tag &orig_curve_tag) {
 
-  MBErrorCode result;
+  moab::ErrorCode result;
 
     result = MBI()->tag_get_handle( GEOM_DIMENSION_TAG_NAME, 1,
-				MB_TYPE_INTEGER, geom_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT );
-    assert( MB_SUCCESS == result );
-    if ( result != MB_SUCCESS )
+				moab::MB_TYPE_INTEGER, geom_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT );
+    assert( moab::MB_SUCCESS == result );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
     result = MBI()->tag_get_handle( GLOBAL_ID_TAG_NAME, 1,
-				MB_TYPE_INTEGER, id_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT);
-    assert( MB_SUCCESS == result );
-    if ( result != MB_SUCCESS )
+				moab::MB_TYPE_INTEGER, id_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT);
+    assert( moab::MB_SUCCESS == result );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
-    result = MBI()->tag_get_handle( "NORMAL", sizeof(MBCartVect), MB_TYPE_OPAQUE,
+    result = MBI()->tag_get_handle( "NORMAL", sizeof(moab::CartVect), moab::MB_TYPE_OPAQUE,
         normal_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT);
-    assert( MB_SUCCESS == result );
-    if ( result != MB_SUCCESS )
+    assert( moab::MB_SUCCESS == result );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
-    result = MBI()->tag_get_handle( "MERGE", 1, MB_TYPE_HANDLE,
+    result = MBI()->tag_get_handle( "MERGE", 1, moab::MB_TYPE_HANDLE,
         merge_tag, moab::MB_TAG_SPARSE|moab::MB_TAG_CREAT );
-    assert( MB_SUCCESS == result ); 
-    if ( result != MB_SUCCESS )
+    assert( moab::MB_SUCCESS == result ); 
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       } 
-    result = MBI()->tag_get_handle( "FACETING_TOL", 1, MB_TYPE_DOUBLE,
+    result = MBI()->tag_get_handle( "FACETING_TOL", 1, moab::MB_TYPE_DOUBLE,
         faceting_tol_tag , moab::MB_TAG_SPARSE|moab::MB_TAG_CREAT );
-    assert( MB_SUCCESS == result );  
-    if ( result != MB_SUCCESS )
+    assert( moab::MB_SUCCESS == result );  
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
-    result = MBI()->tag_get_handle( "GEOMETRY_RESABS", 1,     MB_TYPE_DOUBLE,
+    result = MBI()->tag_get_handle( "GEOMETRY_RESABS", 1,     moab::MB_TYPE_DOUBLE,
                              geometry_resabs_tag, moab::MB_TAG_SPARSE|moab::MB_TAG_CREAT  );
-    assert( MB_SUCCESS == result );  
-    if ( result != MB_SUCCESS )
+    assert( moab::MB_SUCCESS == result );  
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
-    result = MBI()->tag_get_handle( "GEOM_SIZE", 1, MB_TYPE_DOUBLE,
+    result = MBI()->tag_get_handle( "GEOM_SIZE", 1, moab::MB_TYPE_DOUBLE,
 				    size_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT  );
-    assert( (MB_SUCCESS == result) );
-    if ( result != MB_SUCCESS )
+    assert( (moab::MB_SUCCESS == result) );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
     int true_int = 1;    
     result = MBI()->tag_get_handle( "ORIG_CURVE", 1,
-				MB_TYPE_INTEGER, orig_curve_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT, &true_int );
-    assert( MB_SUCCESS == result );
-    if ( result != MB_SUCCESS )
+				moab::MB_TYPE_INTEGER, orig_curve_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT, &true_int );
+    assert( moab::MB_SUCCESS == result );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
     // PROBLEM: MOAB is not consistent with file_set behavior. The tag may not be
     // on the file_set.
-    MBRange file_set;
-    result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET, &faceting_tol_tag,
+    moab::Range file_set;
+    result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET, &faceting_tol_tag,
                                                   NULL, 1, file_set );
 
-    if(gen::error(MB_SUCCESS!=result,"could not get faceting_tol_tag")) 
+    if(gen::error(moab::MB_SUCCESS!=result,"could not get faceting_tol_tag")) 
       {
 	return result;
       }
@@ -2112,86 +2112,86 @@ MBErrorCode get_sealing_mesh_tags( double &facet_tol,
 
     if(gen::error(1!=file_set.size(),"Refacet with newer version of ReadCGM.")) 
       {
-	return MB_FAILURE;
+	return moab::MB_FAILURE;
       }
 
     result = MBI()->tag_get_data( faceting_tol_tag, &file_set.front(), 1,  
                                   &facet_tol );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     result = MBI()->tag_get_data( geometry_resabs_tag, &file_set.front(), 1,  
                                   &sme_resabs_tol );
-    if(MB_SUCCESS != result) 
+    if(moab::MB_SUCCESS != result) 
       {
 	std::cout <<  "absolute tolerance could not be read from file" << std::endl;
       }
 
 
 
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 
   }
 
-  MBErrorCode get_geometry_meshsets( MBRange geometry_sets[], MBTag geom_tag, bool verbose) {
+  moab::ErrorCode get_geometry_meshsets( moab::Range geometry_sets[], moab::Tag geom_tag, bool verbose) {
 
-    MBErrorCode result; 
+    moab::ErrorCode result; 
 
     // get all geometry sets
     for(unsigned dim=0; dim<4; dim++) 
       {
 	void *val[] = {&dim};
-	result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET, &geom_tag,
+	result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET, &geom_tag,
 	  					    val, 1, geometry_sets[dim] );
-	assert(MB_SUCCESS == result);
+	assert(moab::MB_SUCCESS == result);
 
 	// make sure that sets TRACK membership and curves are ordered
-	// MESHSET_TRACK_OWNER=0x1, MESHSET_SET=0x2, MESHSET_ORDERED=0x4      
+	// moab::MESHSET_TRACK_OWNER=0x1, moab::MESHSET_SET=0x2, moab::MESHSET_ORDERED=0x4      
 
-	for(MBRange::iterator i=geometry_sets[dim].begin(); i!=geometry_sets[dim].end(); i++) 
+	for(moab::Range::iterator i=geometry_sets[dim].begin(); i!=geometry_sets[dim].end(); i++) 
 	  {
 	    unsigned int options;
 	    result = MBI()->get_meshset_options(*i, options );
-	    assert(MB_SUCCESS == result);
+	    assert(moab::MB_SUCCESS == result);
     
 	    // if options are wrong change them
 	    if(dim==1) 
 	      {
-		if( !(MESHSET_TRACK_OWNER&options) || !(MESHSET_ORDERED&options) ) 
+		if( !(moab::MESHSET_TRACK_OWNER&options) || !(moab::MESHSET_ORDERED&options) ) 
 		  {
-		    result = MBI()->set_meshset_options(*i, MESHSET_TRACK_OWNER|MESHSET_ORDERED);
-		    assert(MB_SUCCESS == result);
+		    result = MBI()->set_meshset_options(*i, moab::MESHSET_TRACK_OWNER|moab::MESHSET_ORDERED);
+		    assert(moab::MB_SUCCESS == result);
 		  }
 	      } 
 	    else 
 	      {
-		if( !(MESHSET_TRACK_OWNER&options) ) 
+		if( !(moab::MESHSET_TRACK_OWNER&options) ) 
 		  {        
-		    result = MBI()->set_meshset_options(*i, MESHSET_TRACK_OWNER);
-		    assert(MB_SUCCESS == result);
+		    result = MBI()->set_meshset_options(*i, moab::MESHSET_TRACK_OWNER);
+		    assert(moab::MB_SUCCESS == result);
 		  }
 	      }
 	  }
       }
  
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
 
     }
 
-  MBErrorCode check_for_geometry_sets(MBTag geom_tag, bool verbose){
+  moab::ErrorCode check_for_geometry_sets(moab::Tag geom_tag, bool verbose){
 
-    MBErrorCode result; 
+    moab::ErrorCode result; 
         // go get all geometry sets
-        MBRange geometry_sets[4];
+        moab::Range geometry_sets[4];
         result = get_geometry_meshsets( geometry_sets, geom_tag, false);
-        if(gen::error(MB_SUCCESS!=result,"could not get the geometry meshsets")) return result;
+        if(gen::error(moab::MB_SUCCESS!=result,"could not get the geometry meshsets")) return result;
 
         //make sure they're there
         for(unsigned dim=0; dim<4; dim++){
  
-          if(geometry_sets[dim].size() == 0) return MB_FAILURE;
+          if(geometry_sets[dim].size() == 0) return moab::MB_FAILURE;
 
         }
  
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
 

--- a/make_watertight/gen.cpp
+++ b/make_watertight/gen.cpp
@@ -338,7 +338,7 @@ moab::ErrorCode find_closest_vert( const moab::EntityHandle reference_vert,
     moab::AdaptiveKDTree kdtree(MBI()); //, true, 0, moab::MESHSET_TRACK_OWNER);
     // initialize the KD Tree
     moab::EntityHandle root;
-    const char settings[]="MAX_PER_LEAF=6;MAX_DEPTH=50;SPLITS_PER_DIR=1;PLANE_SET=2;moab::MESHSET_FLAGS=0x1;TAG_NAME=0";
+    const char settings[]="MAX_PER_LEAF=6;MAX_DEPTH=50;SPLITS_PER_DIR=1;PLANE_SET=2;MESHSET_FLAGS=0x1;TAG_NAME=0";
     moab::FileOptions fileopts(settings);
 
 

--- a/make_watertight/gen.hpp
+++ b/make_watertight/gen.hpp
@@ -9,10 +9,10 @@
 #include <time.h>
 #include <vector>
 #include <algorithm>
-#include "MBCore.hpp"
-#include "MBRange.hpp"
-#include "MBAdaptiveKDTree.hpp" // for merging verts
-#include "MBCartVect.hpp"
+#include "moab/Core.hpp"
+#include "moab/Range.hpp"
+#include "moab/AdaptiveKDTree.hpp" // for merging verts
+#include "moab/CartVect.hpp"
 
 // SENSE CONVENTIONS
 #define SENSE_FORWARD 1
@@ -20,208 +20,209 @@
 #define SENSE_UNKNOWN 0
 
 
-MBInterface *MBI(); 
+moab::Interface *MBI(); 
 namespace gen {
   bool error( const bool error_has_occured, const std::string message="" );
   
   /// prints a string of the error code returned from MOAB to standard output 
-  void moab_printer(MBErrorCode error_code);
+  void moab_printer(moab::ErrorCode error_code);
 
-  void print_vertex_cubit( const MBEntityHandle vertex );
+  void print_vertex_cubit( const moab::EntityHandle vertex );
 
-  void print_vertex_coords( const MBEntityHandle vertex );
+  void print_vertex_coords( const moab::EntityHandle vertex );
 
-  void print_triangles( const MBRange tris );
+  void print_triangles( const moab::Range tris );
 
-  void print_triangle( const MBEntityHandle triangle, bool print_edges );
+  void print_triangle( const moab::EntityHandle triangle, bool print_edges );
 
-  void print_edge( const MBEntityHandle edge );
+  void print_edge( const moab::EntityHandle edge );
 
-  void print_vertex_count( const MBEntityHandle input_meshset);
+  void print_vertex_count( const moab::EntityHandle input_meshset);
 
-  void print_range( const MBRange range );
+  void print_range( const moab::Range range );
 
-  void print_range_of_edges( const MBRange range );
+  void print_range_of_edges( const moab::Range range );
 
-  void print_arc_of_edges( const std::vector<MBEntityHandle> arc_of_edges );
+  void print_arc_of_edges( const std::vector<moab::EntityHandle> arc_of_edges );
 
-  void print_arcs( const std::vector < std::vector<MBEntityHandle> > arcs );
+  void print_arcs( const std::vector < std::vector<moab::EntityHandle> > arcs );
 
-  void print_loop( const std::vector<MBEntityHandle> loop_of_verts );
+  void print_loop( const std::vector<moab::EntityHandle> loop_of_verts );
 
-MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
-                               const std::vector<MBEntityHandle> arc_of_verts,
+moab::ErrorCode find_closest_vert( const moab::EntityHandle reference_vert,
+                               const std::vector<moab::EntityHandle> arc_of_verts,
                                unsigned &position,
                                const double dist_limit );
 
-  MBErrorCode find_closest_vert( const double tol,
-                                 const MBEntityHandle reference_vert,
-                                 const std::vector<MBEntityHandle> loop_of_verts,
+  moab::ErrorCode find_closest_vert( const double tol,
+                                 const moab::EntityHandle reference_vert,
+                                 const std::vector<moab::EntityHandle> loop_of_verts,
                                  std::vector<unsigned> &positions, 
                                  std::vector<double>   &dists);
-  /*  MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
-                                  const std::vector<std::vector<MBEntityHandle> > loops_of_verts,
+  /*  moab::ErrorCode find_closest_vert( const moab::EntityHandle reference_vert,
+                                  const std::vector<std::vector<moab::EntityHandle> > loops_of_verts,
                                   unsigned int &loop, unsigned int &position, 
                                   double &min_dist);
   */
   // Merge the range of vertices. We do not merge by edges (more
   // stringent) because we do not want to miss corner vertices.
 
-/// finds any vertices within the MBRange vertices that are with in tol of 
+/// finds any vertices within the moab::Range vertices that are with in tol of 
 /// each other and merges them
-  MBErrorCode merge_vertices( MBRange vertices /* in */, 
+  moab::ErrorCode merge_vertices( moab::Range vertices /* in */, 
 			      const  double tol       /* in */);
 			      //bool &merge_vertices_again /* out */);
 
 /// returns the square of the distance between v0 and v1
-  MBErrorCode squared_dist_between_verts( const MBEntityHandle v0, 
-                                          const MBEntityHandle v1, 
+  moab::ErrorCode squared_dist_between_verts( const moab::EntityHandle v0, 
+                                          const moab::EntityHandle v1, 
                                           double &d);
 /// returns the distance between v0 and v1
 
-  double dist_between_verts( const MBCartVect v0, const MBCartVect v1 );
-  MBErrorCode dist_between_verts( const MBEntityHandle v0, const MBEntityHandle v1,
+  double dist_between_verts( const moab::CartVect v0, const moab::CartVect v1 );
+  moab::ErrorCode dist_between_verts( const moab::EntityHandle v0, const moab::EntityHandle v1,
                                   double &d );
   double dist_between_verts( double coords0[], double coords1[] );
-  double dist_between_verts( MBEntityHandle vert0, MBEntityHandle vert1 );                             
+  double dist_between_verts( moab::EntityHandle vert0, moab::EntityHandle vert1 );                             
 
   // Return the length of the curve defined by MBEDGEs or ordered MBVERTEXs.
-  double length( std::vector<MBEntityHandle> curve );
+  double length( std::vector<moab::EntityHandle> curve );
 
   // Given a vertex and vector of edges, return the number of edges adjacent to the vertex.
-  unsigned int n_adj_edges( MBEntityHandle vert, MBRange edges );
+  unsigned int n_adj_edges( moab::EntityHandle vert, moab::Range edges );
 
 // Return true if the edges share a vertex. Does not check for coincident edges.
-  bool edges_adjacent( MBEntityHandle edge0, MBEntityHandle edge1 );
+  bool edges_adjacent( moab::EntityHandle edge0, moab::EntityHandle edge1 );
 
 // get the direction unit vector from one vertex to another vertex
-  //MBErrorCode get_direction( MBEntityHandle from_vert, MBEntityHandle to_vert, double dir[] );
-  MBErrorCode get_direction( const MBEntityHandle from_vert, const MBEntityHandle to_vert,
-                           MBCartVect &dir ); 
+  //moab::ErrorCode get_direction( moab::EntityHandle from_vert, moab::EntityHandle to_vert, double dir[] );
+  moab::ErrorCode get_direction( const moab::EntityHandle from_vert, const moab::EntityHandle to_vert,
+                           moab::CartVect &dir ); 
 
 // from http://www.topcoder.com/tc?module=Static&d1=tutorials&d2=geometry1
-  double edge_point_dist( const MBCartVect a, const MBCartVect b, const MBCartVect c );
-  double edge_point_dist( const MBEntityHandle endpt0, const MBEntityHandle endpt1, 
-                          const MBEntityHandle pt );
-  double edge_point_dist( const MBEntityHandle edge, const MBEntityHandle pt );
+  double edge_point_dist( const moab::CartVect a, const moab::CartVect b, const moab::CartVect c );
+  double edge_point_dist( const moab::EntityHandle endpt0, const moab::EntityHandle endpt1, 
+                          const moab::EntityHandle pt );
+  double edge_point_dist( const moab::EntityHandle edge, const moab::EntityHandle pt );
 
-  MBErrorCode point_curve_min_dist( const std::vector<MBEntityHandle> curve, 
-                                    const MBEntityHandle pt, double &min_dist,
+  moab::ErrorCode point_curve_min_dist( const std::vector<moab::EntityHandle> curve, 
+                                    const moab::EntityHandle pt, double &min_dist,
                                     const double max_dist_along_curve );
-  MBErrorCode point_curve_min_dist( const std::vector<MBEntityHandle> curve, 
-                                    const MBEntityHandle pt, double &min_dist );
+  moab::ErrorCode point_curve_min_dist( const std::vector<moab::EntityHandle> curve, 
+                                    const moab::EntityHandle pt, double &min_dist );
 
-  double triangle_area( const MBCartVect a, const MBCartVect b, const MBCartVect c);
-  MBErrorCode triangle_area( const MBEntityHandle conn[], double &area );
-  MBErrorCode triangle_area( const MBEntityHandle triangle, double &area );
-  double triangle_area( MBRange triangles );
+  double triangle_area( const moab::CartVect a, const moab::CartVect b, const moab::CartVect c);
+  moab::ErrorCode triangle_area( const moab::EntityHandle conn[], double &area );
+  moab::ErrorCode triangle_area( const moab::EntityHandle triangle, double &area );
+  double triangle_area( moab::Range triangles );
   
-  bool triangle_degenerate( const MBEntityHandle triangle );
-  bool triangle_degenerate( const MBEntityHandle v0, const MBEntityHandle v1, const MBEntityHandle v2);
+  bool triangle_degenerate( const moab::EntityHandle triangle );
+  bool triangle_degenerate( const moab::EntityHandle v0, const moab::EntityHandle v1, const moab::EntityHandle v2);
 
-/// gets the normal vectors of all triangles in MBRange triangles and returns them as MBCartVect's in normals
-  MBErrorCode triangle_normals( const MBRange triangles, std::vector<MBCartVect> &normals );
-  MBErrorCode triangle_normal( const MBEntityHandle triangle, MBCartVect &normal );
-  MBErrorCode triangle_normal( const MBEntityHandle v0, const MBEntityHandle v1,
-                               const MBEntityHandle v2, MBCartVect &normal );
-  MBErrorCode triangle_normal( const MBCartVect v0, const MBCartVect v1, 
-                               const MBCartVect v2, MBCartVect &normal ); 
+/// gets the normal vectors of all triangles in moab::Range triangles and returns them as moab::CartVect's in normals
+  moab::ErrorCode triangle_normals( const moab::Range triangles, std::vector<moab::CartVect> &normals );
+  moab::ErrorCode triangle_normal( const moab::EntityHandle triangle, moab::CartVect &normal );
+  moab::ErrorCode triangle_normal( const moab::EntityHandle v0, const moab::EntityHandle v1,
+                               const moab::EntityHandle v2, moab::CartVect &normal );
+  moab::ErrorCode triangle_normal( const moab::CartVect v0, const moab::CartVect v1, 
+                               const moab::CartVect v2, moab::CartVect &normal ); 
 
   // Distance between a point and line. The line is defined by two verts.
   // We are using a line and not a line segment!
   // http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
-  MBErrorCode line_point_dist( const MBEntityHandle line_pt1, const MBEntityHandle line_pt2,
-                               const MBEntityHandle pt0, double &dist );
+  moab::ErrorCode line_point_dist( const moab::EntityHandle line_pt1, const moab::EntityHandle line_pt2,
+                               const moab::EntityHandle pt0, double &dist );
 
   // Project the point onto the line. Not the line segment! 
   // Change the coordinates of the pt0 to the projection.
-  MBErrorCode point_line_projection( const MBEntityHandle line_pt1,     
-                                     const MBEntityHandle line_pt2,             
-                                     const MBEntityHandle pt0 );
+  moab::ErrorCode point_line_projection( const moab::EntityHandle line_pt1,     
+                                     const moab::EntityHandle line_pt2,             
+                                     const moab::EntityHandle pt0 );
 
   // Do not change the coords of pt0. Instead return the projected coords.              
-  MBErrorCode point_line_projection( const MBEntityHandle line_pt1,     
-                                     const MBEntityHandle line_pt2,             
-                                     const MBEntityHandle pt0,              
-                                     MBCartVect &projected_coords,
+  moab::ErrorCode point_line_projection( const moab::EntityHandle line_pt1,     
+                                     const moab::EntityHandle line_pt2,             
+                                     const moab::EntityHandle pt0,              
+                                     moab::CartVect &projected_coords,
                                      double &parameter );  
   // Get the distance of pt0 from line_pt1 if pt0 is projected. No coords are
   // changed in MOAB.
-  MBErrorCode point_line_projection( const MBEntityHandle line_pt1,
-				     const MBEntityHandle line_pt2,
-				     const MBEntityHandle pt0,
+  moab::ErrorCode point_line_projection( const moab::EntityHandle line_pt1,
+				     const moab::EntityHandle line_pt2,
+				     const moab::EntityHandle pt0,
 				     double &dist_along_edge  );
   
-  MBErrorCode ear_clip_polygon( std::vector<MBEntityHandle> polygon_of_verts,
-                                    const MBCartVect plane_normal_vector, MBRange &new_tris );
+  moab::ErrorCode ear_clip_polygon( std::vector<moab::EntityHandle> polygon_of_verts,
+                                    const moab::CartVect plane_normal_vector, moab::Range &new_tris );
 
-  int geom_id_by_handle( const MBEntityHandle set);
+  int geom_id_by_handle( const moab::EntityHandle set);
 
 /// gets the normal vector of each triangle in tris and tags each triangle with its normal vector
-  MBErrorCode save_normals( MBRange tris, MBTag normal_tag );
+  moab::ErrorCode save_normals( moab::Range tris, moab::Tag normal_tag );
 
-  MBErrorCode flip(const MBEntityHandle tri, const MBEntityHandle vert0, 
-                   const MBEntityHandle vert2, const MBEntityHandle surf_set);
+  moab::ErrorCode flip(const moab::EntityHandle tri, const moab::EntityHandle vert0, 
+                   const moab::EntityHandle vert2, const moab::EntityHandle surf_set);
 
 
 /// creates a set of ordered verts from the a set of ordered edges. uses commone vertex between edges to check continuity. 
-  MBErrorCode ordered_verts_from_ordered_edges( const std::vector<MBEntityHandle> ordered_edges,
-                                                std::vector<MBEntityHandle> &ordered_verts );
+  moab::ErrorCode ordered_verts_from_ordered_edges( const std::vector<moab::EntityHandle> ordered_edges,
+                                                std::vector<moab::EntityHandle> &ordered_verts );
 /// returns the average distance between the vertices in arc0 and arc1. assumes the vertices
 /// are ordered appropriately
-  MBErrorCode dist_between_arcs( bool debug,
-                         const std::vector<MBEntityHandle> arc0,
-                         const std::vector<MBEntityHandle> arc1,
+  moab::ErrorCode dist_between_arcs( bool debug,
+                         const std::vector<moab::EntityHandle> arc0,
+                         const std::vector<moab::EntityHandle> arc1,
                          double &dist );
 
   // skin edges are a vector of two vertex handles
     // Hold edges in an array of handles.
   struct edge {
-    MBEntityHandle edge, v0, v1;
+    moab::EntityHandle edge, v0, v1;
   };
   int compare_edge(const void *a, const void *b);
-  MBErrorCode find_skin( MBRange tris, const int dim,                     
-			 // std::vector<std::vector<MBEntityHandle> > &skin_edges,    
-			 MBRange &skin_edges,                         
+  moab::ErrorCode find_skin( moab::Range tris, const int dim,                     
+			 // std::vector<std::vector<moab::EntityHandle> > &skin_edges,    
+			 moab::Range &skin_edges,                         
                          const bool );
-  //MBErrorCode find_skin( const MBRange tris, const int dim, MBRange &skin_edges, const bool );
-  MBErrorCode measure( const MBEntityHandle set, const MBTag geom_tag, double &size, bool debug, bool verbose );
+  //moab::ErrorCode find_skin( const moab::Range tris, const int dim, moab::Range &skin_edges, const bool );
+  moab::ErrorCode measure( const moab::EntityHandle set, const moab::Tag geom_tag, double &size, bool debug, bool verbose );
 
   // Given a curve and surface set, get the relative sense.
   // From CGMA/builds/dbg/include/CubitDefines, CUBIT_UNKNOWN=-1, CUBIT_FORWARD=0, CUBIT_REVERSED=1
-  MBErrorCode get_curve_surf_sense( const MBEntityHandle surf_set, const MBEntityHandle curve_set,
+  moab::ErrorCode get_curve_surf_sense( const moab::EntityHandle surf_set, const moab::EntityHandle curve_set,
                                     int &sense, bool debug = false );
 
-  MBErrorCode surface_sense( MBEntityHandle volume, int num_surfaces,const MBEntityHandle* surfaces,int* senses_out );
-  MBErrorCode surface_sense( MBEntityHandle volume, MBEntityHandle surface, int& sense_out );
+  moab::ErrorCode surface_sense( moab::EntityHandle volume, int num_surfaces,const moab::EntityHandle* surfaces,int* senses_out );
+  moab::ErrorCode surface_sense( moab::EntityHandle volume, moab::EntityHandle surface, int& sense_out );
 
-  MBTag get_tag( const char* name, int size, MBTagType store,MBDataType type, const void* def_value, bool create_if_missing);
+  moab::Tag get_tag( const char* name, int size, moab::TagType store,moab::DataType type, const void* def_value, bool create_if_missing);
 
-  MBErrorCode delete_surface( MBEntityHandle surf, MBTag geom_tag, MBRange tris, int id, bool debug, bool verbose);
+  moab::ErrorCode delete_surface( moab::EntityHandle surf, moab::Tag geom_tag, moab::Range tris, int id, bool debug, bool verbose);
 
-  MBErrorCode remove_surf_sense_data(MBEntityHandle del_surf, bool debug);
+  moab::ErrorCode remove_surf_sense_data(moab::EntityHandle del_surf, bool debug);
 
-  MBErrorCode combine_merged_curve_senses( std::vector<MBEntityHandle> &curves, MBTag merge_tag, bool debug = false) ;
+  moab::ErrorCode combine_merged_curve_senses( std::vector<moab::EntityHandle> &curves, moab::Tag merge_tag, bool debug = false) ;
 
  /// used to get all mesh tags necessary for sealing a mesh
-  MBErrorCode get_sealing_mesh_tags( double &facet_tol,
+  moab::ErrorCode get_sealing_mesh_tags( double &facet_tol,
                              double &sme_resabs_tol,
-                             MBTag &geom_tag, 
-                             MBTag &id_tag, 
-                             MBTag &normal_tag, 
-                             MBTag &merge_tag, 
-                             MBTag &faceting_tol_tag, 
-                             MBTag &geometry_resabs_tag, 
-                             MBTag &size_tag, 
-                             MBTag &orig_curve_tag);
+                             moab::Tag &geom_tag, 
+                             moab::Tag &id_tag, 
+                             moab::Tag &normal_tag, 
+                             moab::Tag &merge_tag, 
+                             moab::Tag &faceting_tol_tag, 
+                             moab::Tag &geometry_resabs_tag, 
+                             moab::Tag &size_tag, 
+                             moab::Tag &orig_curve_tag);
 
  /// sets the tracking and ordering options of meshsets retrieved from the mesh
-  MBErrorCode get_geometry_meshsets( MBRange geometry_sets[], MBTag geom_tag, bool verbose = false);
+  moab::ErrorCode get_geometry_meshsets( moab::Range geometry_sets[], moab::Tag geom_tag, bool verbose = false);
 
  /// returns MB_SUCCESS if there exists geometry sets of each dimension in the model
  /// returns MB_FAILURE if there are no geometry sets of any dimension in the model
-  MBErrorCode check_for_geometry_sets(MBTag geom_tag, bool verbose);
+  moab::ErrorCode check_for_geometry_sets(moab::Tag geom_tag, bool verbose);
 
 }
 
 #endif
+

--- a/make_watertight/gen.hpp
+++ b/make_watertight/gen.hpp
@@ -185,7 +185,7 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 			 MBRange &skin_edges,                         
                          const bool );
   //MBErrorCode find_skin( const MBRange tris, const int dim, MBRange &skin_edges, const bool );
-  MBErrorCode measure( const MBEntityHandle set, const MBTag geom_tag, double &size, bool verbose = true );
+  MBErrorCode measure( const MBEntityHandle set, const MBTag geom_tag, double &size, bool debug, bool verbose );
 
   // Given a curve and surface set, get the relative sense.
   // From CGMA/builds/dbg/include/CubitDefines, CUBIT_UNKNOWN=-1, CUBIT_FORWARD=0, CUBIT_REVERSED=1
@@ -197,9 +197,9 @@ MBErrorCode find_closest_vert( const MBEntityHandle reference_vert,
 
   MBTag get_tag( const char* name, int size, MBTagType store,MBDataType type, const void* def_value, bool create_if_missing);
 
-  MBErrorCode delete_surface( MBEntityHandle surf, MBTag geom_tag, MBRange tris, int id, bool verbose = false);
+  MBErrorCode delete_surface( MBEntityHandle surf, MBTag geom_tag, MBRange tris, int id, bool debug, bool verbose);
 
-  MBErrorCode remove_surf_sense_data(MBEntityHandle del_surf);
+  MBErrorCode remove_surf_sense_data(MBEntityHandle del_surf, bool debug);
 
   MBErrorCode combine_merged_curve_senses( std::vector<MBEntityHandle> &curves, MBTag merge_tag, bool debug = false) ;
 

--- a/make_watertight/make_watertight.cpp
+++ b/make_watertight/make_watertight.cpp
@@ -44,8 +44,8 @@
 
 
 
-MBInterface *MOAB();
-MBErrorCode write_sealed_file( std::string root_filename, double facet_tol, bool is_acis);
+moab::Interface *MOAB();
+moab::ErrorCode write_sealed_file( std::string root_filename, double facet_tol, bool is_acis);
 
 
 
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
 	std::cout << "$ ./make_watertight <input_file.sat>" << std::endl;
 	std::cout << "To facet and zip an ACIS file using a specified facet tolerance:" << std::endl;
 	std::cout << "$ ./make_watertight <input_file.sat> <facet_tolerance>" << std::endl;
-	return MB_FAILURE;
+	return moab::MB_FAILURE;
       }
 
     // The root name does not have an extension
@@ -79,12 +79,12 @@ int main(int argc, char **argv)
     bool is_acis;
 
     // load the input file
-    MBErrorCode result, rval;
-    MBEntityHandle input_set;
+    moab::ErrorCode result, rval;
+    moab::EntityHandle input_set;
 
-    rval = MBI()->create_meshset( MESHSET_SET, input_set );
+    rval = MBI()->create_meshset( moab::MESHSET_SET, input_set );
 
-    if(gen::error(MB_SUCCESS!=rval,"failed to create_meshset"))
+    if(gen::error(moab::MB_SUCCESS!=rval,"failed to create_meshset"))
       {
 	return rval;
       }
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
     if(std::string::npos!=input_name.find("h5m") && (2==argc)) 
       {
 	rval = MBI()->load_file( input_name.c_str(), &input_set );
-	if(gen::error(MB_SUCCESS!=rval,"failed to load_file 0")) 
+	if(gen::error(moab::MB_SUCCESS!=rval,"failed to load_file 0")) 
 	  {
 	    return rval;      
 	  }
@@ -111,14 +111,14 @@ int main(int argc, char **argv)
     //seal the input mesh set
     double facet_tol;
     result= mw_func::make_mesh_watertight(input_set, facet_tol);
-    if(gen::error(MB_SUCCESS!=result, "could not make model watertight")) return result;
+    if(gen::error(moab::MB_SUCCESS!=result, "could not make model watertight")) return result;
 
   
     //write file
     clock_t zip_time = clock();  
     std::cout << "Writing zipped file..." << std::endl;
     write_sealed_file( root_name, facet_tol, is_acis);
-    if(gen::error(MB_SUCCESS!=result, "could not write the sealed mesh to a new file"))
+    if(gen::error(moab::MB_SUCCESS!=result, "could not write the sealed mesh to a new file"))
     return result; 
 
     clock_t write_time = clock();
@@ -130,15 +130,15 @@ int main(int argc, char **argv)
   return 0;  
   }
 
-MBInterface *MBI() 
+moab::Interface *MBI() 
 {
-    static MBCore instance;
-    return &instance;
+  static moab::Core instance;
+  return &instance;
 }
 
-MBErrorCode write_sealed_file( std::string root_filename, double facet_tol, bool is_acis){
+moab::ErrorCode write_sealed_file( std::string root_filename, double facet_tol, bool is_acis){
 
-    MBErrorCode result;
+    moab::ErrorCode result;
     std::string output_filename;
     if(is_acis) {  
       std::stringstream facet_tol_ss;
@@ -147,12 +147,12 @@ MBErrorCode write_sealed_file( std::string root_filename, double facet_tol, bool
     } else {
       output_filename = root_filename + "_zip.h5m";
     }
-    // PROBLEM: If I write the input meshset the writer returns MB_FAILURE.
+    // PROBLEM: If I write the input meshset the writer returns moab::MB_FAILURE.
     // This happens only if I delete vertices when merging.
     // result = MBI()->write_mesh( filename_new.c_str(), &input_meshset, 1);
     result = MBI()->write_mesh( output_filename.c_str() );
-    if (MB_SUCCESS != result) std::cout << "result= " << result << std::endl;
-    assert(MB_SUCCESS == result);  
+    if (moab::MB_SUCCESS != result) std::cout << "result= " << result << std::endl;
+    assert(moab::MB_SUCCESS == result);  
 
   return result; 
 }

--- a/make_watertight/mw_fix.cpp
+++ b/make_watertight/mw_fix.cpp
@@ -43,7 +43,7 @@ const char GEOM_SENSE_2_TAG_NAME[] = "GEOM_SENSE_2";
 const char GEOM_SENSE_N_ENTS_TAG_NAME[] = "GEOM_SENSE_N_ENTS";
 const char GEOM_SENSE_N_SENSES_TAG_NAME[] = "GEOM_SENSE_N_SENSES"; 
 
-MBInterface *MBI();
+moab::Interface *MBI();
 
 
 char* sense_printer( int sense){
@@ -53,72 +53,72 @@ char* sense_printer( int sense){
   if ( sense == 0 ) return "UNKNOWN (0)";
 }
 
-void moab_printer(MBErrorCode error_code)
+void moab_printer(moab::ErrorCode error_code)
 {
-  if ( error_code == MB_INDEX_OUT_OF_RANGE )
+  if ( error_code == moab::MB_INDEX_OUT_OF_RANGE )
     {
-      std::cerr << "ERROR: MB_INDEX_OUT_OF_RANGE" << std::endl;
+      std::cerr << "ERROR: moab::MB_INDEX_OUT_OF_RANGE" << std::endl;
     }
-  if ( error_code == MB_MEMORY_ALLOCATION_FAILED )
+  if ( error_code == moab::MB_MEMORY_ALLOCATION_FAILED )
     {
-      std::cerr << "ERROR: MB_MEMORY_ALLOCATION_FAILED" << std::endl;
+      std::cerr << "ERROR: moab::MB_MEMORY_ALLOCATION_FAILED" << std::endl;
     }
-  if ( error_code == MB_ENTITY_NOT_FOUND )
+  if ( error_code == moab::MB_ENTITY_NOT_FOUND )
     {
-      std::cerr << "ERROR: MB_ENTITY_NOT_FOUND" << std::endl;
+      std::cerr << "ERROR: moab::MB_ENTITY_NOT_FOUND" << std::endl;
     }
-  if ( error_code == MB_MULTIPLE_ENTITIES_FOUND )
+  if ( error_code == moab::MB_MULTIPLE_ENTITIES_FOUND )
     {
-      std::cerr << "ERROR: MB_MULTIPLE_ENTITIES_FOUND" << std::endl;
+      std::cerr << "ERROR: moab::MB_MULTIPLE_ENTITIES_FOUND" << std::endl;
     }
-  if ( error_code == MB_TAG_NOT_FOUND )
+  if ( error_code == moab::MB_TAG_NOT_FOUND )
     {
-      std::cerr << "ERROR: MB_TAG_NOT_FOUND" << std::endl;
+      std::cerr << "ERROR: moab::MB_TAG_NOT_FOUND" << std::endl;
     }
-  if ( error_code == MB_FILE_DOES_NOT_EXIST )
+  if ( error_code == moab::MB_FILE_DOES_NOT_EXIST )
     {
-      std::cerr << "ERROR: MB_FILE_DOES_NOT_EXIST" << std::endl;
+      std::cerr << "ERROR: moab::MB_FILE_DOES_NOT_EXIST" << std::endl;
     }    
-  if ( error_code == MB_FILE_WRITE_ERROR )
+  if ( error_code == moab::MB_FILE_WRITE_ERROR )
     {
-      std::cerr << "ERROR: MB_FILE_WRITE_ERROR" << std::endl;
+      std::cerr << "ERROR: moab::MB_FILE_WRITE_ERROR" << std::endl;
     }    
-  if ( error_code == MB_ALREADY_ALLOCATED )
+  if ( error_code == moab::MB_ALREADY_ALLOCATED )
     {
-      std::cerr << "ERROR: MB_ALREADY_ALLOCATED" << std::endl;
+      std::cerr << "ERROR: moab::MB_ALREADY_ALLOCATED" << std::endl;
     }    
-  if ( error_code == MB_VARIABLE_DATA_LENGTH )
+  if ( error_code == moab::MB_VARIABLE_DATA_LENGTH )
     {
-      std::cerr << "ERROR: MB_VARIABLE_DATA_LENGTH" << std::endl;
+      std::cerr << "ERROR: moab::MB_VARIABLE_DATA_LENGTH" << std::endl;
     }  
-  if ( error_code == MB_INVALID_SIZE )
+  if ( error_code == moab::MB_INVALID_SIZE )
     {
-      std::cerr << "ERROR: MB_INVALID_SIZE" << std::endl;
+      std::cerr << "ERROR: moab::MB_INVALID_SIZE" << std::endl;
     }  
-  if ( error_code == MB_UNSUPPORTED_OPERATION )
+  if ( error_code == moab::MB_UNSUPPORTED_OPERATION )
     {
-      std::cerr << "ERROR: MB_UNSUPPORTED_OPERATION" << std::endl;
+      std::cerr << "ERROR: moab::MB_UNSUPPORTED_OPERATION" << std::endl;
     }  
-  if ( error_code == MB_UNHANDLED_OPTION )
+  if ( error_code == moab::MB_UNHANDLED_OPTION )
     {
-      std::cerr << "ERROR: MB_UNHANDLED_OPTION" << std::endl;
+      std::cerr << "ERROR: moab::MB_UNHANDLED_OPTION" << std::endl;
     }  
-  if ( error_code == MB_FAILURE )
+  if ( error_code == moab::MB_FAILURE )
     {
-      std::cerr << "ERROR: MB_FAILURE" << std::endl;
+      std::cerr << "ERROR: moab::MB_FAILURE" << std::endl;
     }  
   return;
 }
 
 
-MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[], 
-                                          const MBTag geom_tag,
-                                          const MBTag size_tag,
+moab::ErrorCode get_geom_size_before_sealing( const moab::Range geom_sets[], 
+                                          const moab::Tag geom_tag,
+                                          const moab::Tag size_tag,
                                           bool verbose ) {
-  MBErrorCode rval;
+  moab::ErrorCode rval;
   for(int dim=1; dim <= 3 ; dim++) {
     std::cout << "dim = " << dim << std::endl;
-    for(MBRange::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) {
+    for(moab::Range::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) {
       double size = 0;
 	//std::cout << "*i =" << *i << std::endl;
 	//std::cout << "geom_tag =" << geom_tag << std::endl;
@@ -126,9 +126,9 @@ MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[],
 
 
       rval = gen::measure( *i, geom_tag, size, false, verbose );
-      if(gen::error(MB_SUCCESS!=rval,"could not measure")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not measure")) return rval;
       rval = MBI()->tag_set_data( size_tag, &(*i), 1, &size );
-      if(gen::error(MB_SUCCESS!=rval,"could not set size tag")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not set size tag")) return rval;
 
 	//std::cout << "*i =" << *i << std::endl;
 	//std::cout << "geom_tag =" << geom_tag << std::endl;
@@ -136,11 +136,11 @@ MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[],
 
     }
   }
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
 
-MBErrorCode get_senses(MBEntityHandle entity,
-    std::vector<MBEntityHandle> &wrt_entities, std::vector<int> &senses)
+moab::ErrorCode get_senses(moab::EntityHandle entity,
+    std::vector<moab::EntityHandle> &wrt_entities, std::vector<int> &senses)
 {
   //
   // the question here is: the wrt_entities is supplied or not?
@@ -148,9 +148,9 @@ MBErrorCode get_senses(MBEntityHandle entity,
   int edim = 1;
 
   if (-1 == edim)
-    return MB_FAILURE;// not geometry entity
+    return moab::MB_FAILURE;// not geometry entity
 
-  MBErrorCode rval;
+  moab::ErrorCode rval;
   wrt_entities.clear();
   senses.clear();
 
@@ -159,22 +159,22 @@ MBErrorCode get_senses(MBEntityHandle entity,
     
     const void *dum_ptr;
     int num_ents;
-    unsigned flags = MB_TAG_SPARSE;
+    unsigned flags = moab::MB_TAG_SPARSE;
   
-    MBTag senseNEntsTag;
-    rval = MBI() -> tag_get_handle(GEOM_SENSE_N_ENTS_TAG_NAME, 0 , MB_TYPE_HANDLE, senseNEntsTag, flags);
-    if (gen::error(MB_SUCCESS!=rval, "could not get ent sense handles")) return rval;
+    moab::Tag senseNEntsTag;
+    rval = MBI() -> tag_get_handle(GEOM_SENSE_N_ENTS_TAG_NAME, 0 , moab::MB_TYPE_HANDLE, senseNEntsTag, flags);
+    if (gen::error(moab::MB_SUCCESS!=rval, "could not get ent sense handles")) return rval;
     rval = MBI()->tag_get_by_ptr(senseNEntsTag, &entity, 1, &dum_ptr, &num_ents);
-    if (gen::error(MB_SUCCESS!=rval, "could not get ent sense data")) return rval;
-    const MBEntityHandle *ents_data = static_cast<const MBEntityHandle*> (dum_ptr);
+    if (gen::error(moab::MB_SUCCESS!=rval, "could not get ent sense data")) return rval;
+    const moab::EntityHandle *ents_data = static_cast<const moab::EntityHandle*> (dum_ptr);
     std::copy(ents_data, ents_data + num_ents, std::back_inserter(wrt_entities));
 
-    MBTag senseNSensesTag;
-    rval = MBI()->tag_get_handle(GEOM_SENSE_N_SENSES_TAG_NAME, 0 , MB_TYPE_INTEGER, senseNSensesTag, flags);
-    if (gen::error(MB_SUCCESS!=rval, "could not get senses handle")) return rval;
+    moab::Tag senseNSensesTag;
+    rval = MBI()->tag_get_handle(GEOM_SENSE_N_SENSES_TAG_NAME, 0 , moab::MB_TYPE_INTEGER, senseNSensesTag, flags);
+    if (gen::error(moab::MB_SUCCESS!=rval, "could not get senses handle")) return rval;
     rval = MBI()->tag_get_by_ptr(senseNSensesTag, &entity, 1, &dum_ptr,
         &num_ents);
-    if (gen::error(MB_SUCCESS!=rval, "could not get senses data")) return rval;
+    if (gen::error(moab::MB_SUCCESS!=rval, "could not get senses data")) return rval;
 
     const int *senses_data = static_cast<const int*> (dum_ptr);
     std::copy(senses_data, senses_data + num_ents, std::back_inserter(senses));
@@ -182,9 +182,9 @@ MBErrorCode get_senses(MBEntityHandle entity,
   }/* else // face in volume, edim == 2
   {
     
-    MBEntityHandle sense_data[2] = { 0, 0 };
+    moab::EntityHandle sense_data[2] = { 0, 0 };
     rval = MBI()->tag_get_data(GEOM_SENSE_2_TAG_NAME, &entity, 1, sense_data);
-    if (MB_SUCCESS != rval)
+    if (moab::MB_SUCCESS != rval)
       return rval;
     if (sense_data[0] != 0 && sense_data[1] == sense_data[0]) {
       wrt_entities.push_back(sense_data[0]);
@@ -212,7 +212,7 @@ MBErrorCode get_senses(MBEntityHandle entity,
 
   for (unsigned int index=0; index<wrt_entities.size(); index++)
   {
-    MBEntityHandle wrt_ent=wrt_entities[index];
+    moab::EntityHandle wrt_ent=wrt_entities[index];
     if (wrt_ent )
     {
       if (MBI()->contains_entities(modelSet, &wrt_ent, 1))
@@ -227,7 +227,7 @@ MBErrorCode get_senses(MBEntityHandle entity,
   senses.resize(currentSize);
   //
   */
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
   int main(int argc, char **argv) {
 
@@ -249,7 +249,7 @@ MBErrorCode get_senses(MBEntityHandle entity,
 	std::cout << "$ ./make_watertight <input_file.sat>" << std::endl;
 	std::cout << "To facet and zip an ACIS file using a specified facet tolerance:" << std::endl;
 	std::cout << "$ ./make_watertight <input_file.sat> <facet_tolerance>" << std::endl;
-	return MB_FAILURE;
+	return moab::MB_FAILURE;
       }
 
     // The root name does not have an extension
@@ -260,12 +260,12 @@ MBErrorCode get_senses(MBEntityHandle entity,
     bool is_acis;
 
     // load the input file
-    MBErrorCode result, rval;
-    MBEntityHandle input_set;
+    moab::ErrorCode result, rval;
+    moab::EntityHandle input_set;
 
-    rval = MBI()->create_meshset( MESHSET_SET, input_set );
+    rval = MBI()->create_meshset( moab::MESHSET_SET, input_set );
 
-    if(gen::error(MB_SUCCESS!=rval,"failed to create_meshset"))
+    if(gen::error(moab::MB_SUCCESS!=rval,"failed to create_meshset"))
       {
 	return rval;
       }
@@ -279,7 +279,7 @@ MBErrorCode get_senses(MBEntityHandle entity,
     if(std::string::npos!=input_name.find("h5m") && (2==argc)) 
       {
 	rval = MBI()->load_file( input_name.c_str(), &input_set );
-	if(gen::error(MB_SUCCESS!=rval,"failed to load_file 0")) 
+	if(gen::error(moab::MB_SUCCESS!=rval,"failed to load_file 0")) 
 	  {
 	    return rval;      
 	  }
@@ -313,91 +313,91 @@ MBErrorCode get_senses(MBEntityHandle entity,
 	options += facet_tol_ss.str();
 	if(debug) std::cout << "  options=" << options << std::endl;
 	rval = MBI()->load_file( input_name.c_str(), &input_set, options.c_str() );
-	if(gen::error(MB_SUCCESS!=rval,"failed to load_file 1")) return rval;      
+	if(gen::error(moab::MB_SUCCESS!=rval,"failed to load_file 1")) return rval;      
 
       // write an HDF5 file of facets with known tolerance   
 	std::string facet_tol_filename = root_name + "_" + facet_tol_ss.str() + ".h5m";
 	rval = MBI()->write_mesh( facet_tol_filename.c_str() );
-	if(gen::error(MB_SUCCESS!=rval,"failed to write_mesh 0")) return rval;      
+	if(gen::error(moab::MB_SUCCESS!=rval,"failed to write_mesh 0")) return rval;      
 	is_acis = true;
       } 
     else 
       {
 	std::cout << "incorrect input arguments" << std::endl;
-	return MB_FAILURE;
+	return moab::MB_FAILURE;
       }
      //not required if  only doing this with h5m files
      */
 
     // create tags
     clock_t load_time = clock();    
-    MBTag geom_tag, id_tag, normal_tag, merge_tag, faceting_tol_tag, 
+    moab::Tag geom_tag, id_tag, normal_tag, merge_tag, faceting_tol_tag, 
       geometry_resabs_tag, size_tag, orig_curve_tag;
   
     result = MBI()->tag_get_handle( GEOM_DIMENSION_TAG_NAME, 1,
-				MB_TYPE_INTEGER, geom_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT );
-    assert( MB_SUCCESS == result );
-    if ( result != MB_SUCCESS )
+				moab::MB_TYPE_INTEGER, geom_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT );
+    assert( moab::MB_SUCCESS == result );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
     result = MBI()->tag_get_handle( GLOBAL_ID_TAG_NAME, 1,
-				MB_TYPE_INTEGER, id_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT);
-    assert( MB_SUCCESS == result );
-    if ( result != MB_SUCCESS )
+				moab::MB_TYPE_INTEGER, id_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT);
+    assert( moab::MB_SUCCESS == result );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
-    result = MBI()->tag_get_handle( "NORMAL", sizeof(MBCartVect), MB_TYPE_OPAQUE,
+    result = MBI()->tag_get_handle( "NORMAL", sizeof(moab::CartVect), moab::MB_TYPE_OPAQUE,
         normal_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT);
-    assert( MB_SUCCESS == result );
-    if ( result != MB_SUCCESS )
+    assert( moab::MB_SUCCESS == result );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
-    result = MBI()->tag_get_handle( "MERGE", 1, MB_TYPE_HANDLE,
+    result = MBI()->tag_get_handle( "MERGE", 1, moab::MB_TYPE_HANDLE,
         merge_tag, moab::MB_TAG_SPARSE|moab::MB_TAG_CREAT );
-    assert( MB_SUCCESS == result ); 
-    if ( result != MB_SUCCESS )
+    assert( moab::MB_SUCCESS == result ); 
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       } 
-    result = MBI()->tag_get_handle( "FACETING_TOL", 1, MB_TYPE_DOUBLE,
+    result = MBI()->tag_get_handle( "FACETING_TOL", 1, moab::MB_TYPE_DOUBLE,
         faceting_tol_tag , moab::MB_TAG_SPARSE|moab::MB_TAG_CREAT );
-    assert( MB_SUCCESS == result );  
-    if ( result != MB_SUCCESS )
+    assert( moab::MB_SUCCESS == result );  
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
-    result = MBI()->tag_get_handle( "GEOMETRY_RESABS", 1,     MB_TYPE_DOUBLE,
+    result = MBI()->tag_get_handle( "GEOMETRY_RESABS", 1,     moab::MB_TYPE_DOUBLE,
                              geometry_resabs_tag, moab::MB_TAG_SPARSE|moab::MB_TAG_CREAT  );
-    assert( MB_SUCCESS == result );  
-    if ( result != MB_SUCCESS )
+    assert( moab::MB_SUCCESS == result );  
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
-    result = MBI()->tag_get_handle( "GEOM_SIZE", 1, MB_TYPE_DOUBLE,
+    result = MBI()->tag_get_handle( "GEOM_SIZE", 1, moab::MB_TYPE_DOUBLE,
 				    size_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT  );
-    assert( (MB_SUCCESS == result) );
-    if ( result != MB_SUCCESS )
+    assert( (moab::MB_SUCCESS == result) );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
     int true_int = 1;    
     result = MBI()->tag_get_handle( "ORIG_CURVE", 1,
-				MB_TYPE_INTEGER, orig_curve_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT, &true_int );
-    assert( MB_SUCCESS == result );
-    if ( result != MB_SUCCESS )
+				moab::MB_TYPE_INTEGER, orig_curve_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT, &true_int );
+    assert( moab::MB_SUCCESS == result );
+    if ( result != moab::MB_SUCCESS )
       {
 	moab_printer(result);
       }
     // PROBLEM: MOAB is not consistent with file_set behavior. The tag may not be
     // on the file_set.
-    MBRange file_set;
-    result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET, &faceting_tol_tag,
+    moab::Range file_set;
+    result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET, &faceting_tol_tag,
                                                   NULL, 1, file_set );
 
-    if(gen::error(MB_SUCCESS!=result,"could not get faceting_tol_tag")) 
+    if(gen::error(moab::MB_SUCCESS!=result,"could not get faceting_tol_tag")) 
       {
 	return result;
       }
@@ -406,16 +406,16 @@ MBErrorCode get_senses(MBEntityHandle entity,
 
     if(gen::error(1!=file_set.size(),"Refacet with newer version of ReadCGM.")) 
       {
-	return MB_FAILURE;
+	return moab::MB_FAILURE;
       }
 
     double facet_tol, sme_resabs_tol=1e-6;
     result = MBI()->tag_get_data( faceting_tol_tag, &file_set.front(), 1,  
                                   &facet_tol );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     result = MBI()->tag_get_data( geometry_resabs_tag, &file_set.front(), 1,  
                                   &sme_resabs_tol );
-    if(MB_SUCCESS != result) 
+    if(moab::MB_SUCCESS != result) 
       {
 	std::cout <<  "absolute tolerance could not be read from file" << std::endl;
       }
@@ -433,39 +433,39 @@ MBErrorCode get_senses(MBEntityHandle entity,
  
     
     // get all geometry sets
-    MBRange geom_sets[4];
+    moab::Range geom_sets[4];
     for(unsigned dim=0; dim<4; dim++) 
       {
 	void *val[] = {&dim};
-	result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET, &geom_tag,
+	result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET, &geom_tag,
 	  					    val, 1, geom_sets[dim] );
 	std::cout << "Get entities by type and tag" << std::endl;
 
-	assert(MB_SUCCESS == result);
+	assert(moab::MB_SUCCESS == result);
 
 	// make sure that sets TRACK membership and curves are ordered
-	// MESHSET_TRACK_OWNER=0x1, MESHSET_SET=0x2, MESHSET_ORDERED=0x4
-	for(MBRange::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) 
+	// moab::MESHSET_TRACK_OWNER=0x1, moab::MESHSET_SET=0x2, moab::MESHSET_ORDERED=0x4
+	for(moab::Range::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) 
 	  {
 	    unsigned int options;
 	    result = MBI()->get_meshset_options(*i, options );
-	    assert(MB_SUCCESS == result);
+	    assert(moab::MB_SUCCESS == result);
     
 	    // if options are wrong change them
 	    if(dim==1) 
 	      {
-		if( !(MESHSET_TRACK_OWNER&options) || !(MESHSET_ORDERED&options) ) 
+		if( !(moab::MESHSET_TRACK_OWNER&options) || !(moab::MESHSET_ORDERED&options) ) 
 		  {
-		    result = MBI()->set_meshset_options(*i, MESHSET_TRACK_OWNER|MESHSET_ORDERED);
-		    assert(MB_SUCCESS == result);
+		    result = MBI()->set_meshset_options(*i, moab::MESHSET_TRACK_OWNER|moab::MESHSET_ORDERED);
+		    assert(moab::MB_SUCCESS == result);
 		  }
 	      } 
 	    else 
 	      {
-		if( !(MESHSET_TRACK_OWNER&options) ) 
+		if( !(moab::MESHSET_TRACK_OWNER&options) ) 
 		  {        
-		    result = MBI()->set_meshset_options(*i, MESHSET_TRACK_OWNER);
-		    assert(MB_SUCCESS == result);
+		    result = MBI()->set_meshset_options(*i, moab::MESHSET_TRACK_OWNER);
+		    assert(moab::MB_SUCCESS == result);
 		  }
 	      }
 	  }
@@ -480,7 +480,7 @@ MBErrorCode get_senses(MBEntityHandle entity,
       {
 	std::cout << "I am checking the geometry size" << std::endl;
 	result = get_geom_size_before_sealing( geom_sets, geom_tag, size_tag, verbose );
-	if(gen::error(MB_SUCCESS!=result,"measuring geom size failed"))
+	if(gen::error(moab::MB_SUCCESS!=result,"measuring geom size failed"))
 	  {
 	    return result;
 	  }
@@ -491,10 +491,10 @@ MBErrorCode get_senses(MBEntityHandle entity,
     std::cout << "Get entity count before sealing" << std::endl;
     // Get entity count before sealing.
     int orig_n_tris;
-    result = MBI()->get_number_entities_by_type( 0, MBTRI, orig_n_tris );
+    result = MBI()->get_number_entities_by_type( 0, moab::MBTRI, orig_n_tris );
     std::cout << result << std::endl;
 
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
 
     std::cout << "==================================" << std::endl;
     std::cout << "  Input faceted geometry contains: " << std::endl;
@@ -542,11 +542,11 @@ MBErrorCode get_senses(MBEntityHandle entity,
     
     for( unsigned int i=0; i<geom_sets[1].size(); i++)
     {
-    MBEntityHandle curve = geom_sets[1][i];
-    std::vector<MBEntityHandle> surfs;
+    moab::EntityHandle curve = geom_sets[1][i];
+    std::vector<moab::EntityHandle> surfs;
     std::vector<int> senses;
     rval = gt.get_senses( curve, surfs, senses);
-    if(gen::error(MB_SUCCESS!=result,"could not get curve senses")) return result;
+    if(gen::error(moab::MB_SUCCESS!=result,"could not get curve senses")) return result;
     std::cout << "Number of senses for curve " << gen::geom_id_by_handle(curve) << " = " << senses.size() << std::endl;
     for (unsigned int index=0; index<senses.size() ; index++)
     { 
@@ -567,11 +567,11 @@ MBErrorCode get_senses(MBEntityHandle entity,
 
     for( unsigned int i=0; i<geom_sets[2].size(); i++)
     {
-    MBEntityHandle surf = geom_sets[2][i];
-    std::vector<MBEntityHandle> vols;
+    moab::EntityHandle surf = geom_sets[2][i];
+    std::vector<moab::EntityHandle> vols;
     std::vector<int> surf_senses;
     rval = gt.get_senses( surf, vols, surf_senses);
-    if(gen::error(MB_SUCCESS!=result,"could not get surface senses")) return result;
+    if(gen::error(moab::MB_SUCCESS!=result,"could not get surface senses")) return result;
     std::cout << "Number of senses for surface " << gen::geom_id_by_handle(surf) << " = " << surf_senses.size() << std::endl;
     for (unsigned int index=0; index<surf_senses.size() ; index++)
     { 
@@ -587,20 +587,20 @@ MBErrorCode get_senses(MBEntityHandle entity,
     std::cout << " Vertex Coordinates " << std::endl;
     std::cout << "=====================================" << std::endl;
 
-    MBRange verts;
-    rval = MBI()->get_entities_by_type(0, MBVERTEX, verts);
-    if(gen::error(MB_SUCCESS!=result,"could not get vertex handles")) return result;
+    moab::Range verts;
+    rval = MBI()->get_entities_by_type(0, moab::MBVERTEX, verts);
+    if(gen::error(moab::MB_SUCCESS!=result,"could not get vertex handles")) return result;
     double x[geom_sets[0].size()];
     double y[geom_sets[0].size()];
     double z[geom_sets[0].size()];
 
 
     rval = MBI()-> get_coords( verts, &x[0], &y[0], &z[0]);
-    if(gen::error(MB_SUCCESS!=result,"could not get coordinates of the vertices")) return result;
+    if(gen::error(moab::MB_SUCCESS!=result,"could not get coordinates of the vertices")) return result;
 
 
     int j=0;
-    for (MBRange::const_iterator i = verts.begin(); i!=verts.end(); i++)
+    for (moab::Range::const_iterator i = verts.begin(); i!=verts.end(); i++)
     {
         
      std::cout << "Vertex ID = " << *i << std::endl;
@@ -614,7 +614,7 @@ MBErrorCode get_senses(MBEntityHandle entity,
 }
 //==========EOL=============//
 
-MBInterface *MBI() {
-    static MBCore instance;
+moab::Interface *MBI() {
+  static moab::Core instance;
     return &instance;
   }

--- a/make_watertight/mw_fix.cpp
+++ b/make_watertight/mw_fix.cpp
@@ -125,7 +125,7 @@ MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[],
 	//std::cout << "size =" << size << std::endl;
 
 
-      rval = gen::measure( *i, geom_tag, size, verbose );
+      rval = gen::measure( *i, geom_tag, size, false, verbose );
       if(gen::error(MB_SUCCESS!=rval,"could not measure")) return rval;
       rval = MBI()->tag_set_data( size_tag, &(*i), 1, &size );
       if(gen::error(MB_SUCCESS!=rval,"could not set size tag")) return rval;

--- a/make_watertight/mw_func.cpp
+++ b/make_watertight/mw_func.cpp
@@ -783,7 +783,9 @@ MBErrorCode seal_loop( bool debug,
       }
 
       // check to ensure that the endpt sets aren't degenerate
-      if(2==endpt_sets.size() && endpts.front()==endpts.back()) {
+
+      if(2==endpt_sets.size() && endpts.front()==endpts.back() && debug ) {
+
 	std::cout << "  warning9: curve " << gen::geom_id_by_handle(curve_sets[i]) 
                   << " geometric endpoints degenerate" << std::endl;
       }
@@ -798,7 +800,7 @@ MBErrorCode seal_loop( bool debug,
           "geometric verts inconsistent with curve")) return MB_FAILURE;
       } else {
         if(curve.front()==curve.back()) 
-          std::cout << "  warning10: degenerate curve endpts" << std::endl;
+          if(debug) std::cout << "  warning10: degenerate curve endpts" << std::endl;
         if(gen::error(curve.front()!=endpts.front() && curve.front()!=endpts.back(),
 		      "endpts not consistent")) return MB_FAILURE;
         if(gen::error(curve.back()!=endpts.front() && curve.back()!=endpts.back(),

--- a/make_watertight/mw_func.cpp
+++ b/make_watertight/mw_func.cpp
@@ -107,9 +107,11 @@ MBErrorCode prepare_curves(MBRange &curve_sets,
     during zipping anyhow. Doing this now removes small curves from zipping and
     reduces ambiguity. */
     if(FACET_TOL > gen::length(curve_edges)) {
-      std::cout << "  deleted curve " << id << ", length=" << gen::length(curve_edges) 
-                << " cm, n_verts=" << curve_edges.size()+1 << std::endl;
-
+      if (debug)
+        {
+          std::cout << "  deleted curve " << id << ", length=" << gen::length(curve_edges) 
+          << " cm, n_verts=" << curve_edges.size()+1 << std::endl;
+        }
       // get the endpoints of the curve
       MBRange endpt_sets;
       result = MBI()->get_child_meshsets( *i, endpt_sets );

--- a/make_watertight/mw_func.cpp
+++ b/make_watertight/mw_func.cpp
@@ -1013,7 +1013,7 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
 
         // Get the curves and determine the number of unmerged curves
         std::vector<MBEntityHandle> curve_sets, unmerged_curve_sets;
-        result = get_unmerged_curves( *i , curve_sets, unmerged_curve_sets, merge_tag, verbose);
+        result = get_unmerged_curves( *i , curve_sets, unmerged_curve_sets, merge_tag, verbose, debug);
         if(gen::error(MB_SUCCESS!=result, " could not get the curves and unmerged curves" )) return result; 
       
 
@@ -1486,7 +1486,11 @@ MBErrorCode delete_sealing_tags( MBTag normal_tag, MBTag merge_tag, MBTag size_t
   return result; 
 }
 
-MBErrorCode get_unmerged_curves( MBEntityHandle surface, std::vector<MBEntityHandle> &curves, std::vector<MBEntityHandle> &unmerged_curves, MBTag merge_tag, bool verbose) {
+MBErrorCode get_unmerged_curves( MBEntityHandle surface, std::vector<MBEntityHandle> &curves, 
+                                 std::vector<MBEntityHandle> &unmerged_curves, 
+                                 MBTag merge_tag, 
+                                 bool verbose, 
+                                 bool debug) {
 
   MBErrorCode result; 
 
@@ -1505,7 +1509,7 @@ MBErrorCode get_unmerged_curves( MBEntityHandle surface, std::vector<MBEntityHan
         if(MB_TAG_NOT_FOUND == result) {
           curve = *j;
         } else if(MB_SUCCESS == result) {
-	  if(verbose) {
+	  if(debug) {
             std::cout << "  curve_id=" << gen::geom_id_by_handle(*j) 
                       << " is entity_to_delete" << std::endl;
           }

--- a/make_watertight/mw_func.cpp
+++ b/make_watertight/mw_func.cpp
@@ -1020,7 +1020,7 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
         // If all of the curves are merged, remove the surfaces facets.
         if(unmerged_curve_sets.empty()) {
        
-          result = gen::delete_surface( *i , geom_tag, tris, surf_id); 
+          result = gen::delete_surface( *i , geom_tag, tris, surf_id, debug, verbose); 
           if( gen::error(MB_SUCCESS!=result, "could not delete surface" )) return result;                                              
           // adjust iterator so *i is still the same surface
           i = surface_sets.erase(i) - 1;
@@ -1265,6 +1265,7 @@ MBErrorCode fix_normals(MBRange surface_sets, MBTag id_tag, MBTag normal_tag, co
 MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[], 
                                           const MBTag geom_tag,
                                           const MBTag size_tag,
+                                          bool debug,
                                           bool verbose ) 
 {
   MBErrorCode rval;
@@ -1274,7 +1275,7 @@ MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[],
       {
 	double size;
 	//std::cout << "dim = " << dim << " *i =" << *i << std::endl;
-	rval = gen::measure( *i, geom_tag, size, verbose );
+	rval = gen::measure( *i, geom_tag, size, debug, verbose );
 	//std::cout << " here in gen mesaure" << std::endl;
 	if(gen::error(MB_SUCCESS!=rval,"could not measure")) 
 	  {
@@ -1301,8 +1302,9 @@ MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[],
                                          const MBTag geom_tag,
                                          const MBTag size_tag,
                                          const double FACET_TOL,
+                                         bool debug,
                                          bool verbose ) {
-  const bool debug = false;
+  
       // save the largest difference for each dimension
       struct size_data {
         double orig_size, new_size, diff, percent;
@@ -1324,7 +1326,7 @@ MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[],
 	    std::cout << "rval=" << rval << " id=" << gen::geom_id_by_handle(*i) << std::endl;
 	  }
 	  assert(MB_SUCCESS == rval);
-	  rval = gen::measure( *i, geom_tag, new_size, verbose );
+	  rval = gen::measure( *i, geom_tag, new_size, debug, verbose );
 	  assert(MB_SUCCESS == rval);
 
           // Remember the largest difference and associated percent difference
@@ -1753,7 +1755,7 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     // If desired, find each entity's size before sealing.
     if(check_geom_size) 
       {
-	result = get_geom_size_before_sealing( geom_sets, geom_tag, size_tag, verbose );
+	result = get_geom_size_before_sealing( geom_sets, geom_tag, size_tag, debug, verbose );
 	if(gen::error(MB_SUCCESS!=result,"measuring geom size failed")) return result;
       }
     
@@ -1815,7 +1817,7 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     // As sanity check, did zipping drastically change the entity's size?
     if(check_geom_size && verbose) {
       std::cout << "Checking size change of zipped entities..." << std::endl;
-      result = get_geom_size_after_sealing( geom_sets, geom_tag, size_tag, FACET_TOL );
+      result = get_geom_size_after_sealing( geom_sets, geom_tag, size_tag, FACET_TOL, debug, verbose );
       if(gen::error(MB_SUCCESS!=result,"measuring geom size failed")) return result;
     }
    

--- a/make_watertight/mw_func.cpp
+++ b/make_watertight/mw_func.cpp
@@ -1765,7 +1765,7 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     
 
     
-    if (verbose) std::cout << "Get entity count before sealing" << std::endl;
+    if (verbose) std::cout << "Getting entity count before sealing..." << std::endl;
     // Get entity count before sealing.
     int orig_n_tris;
     result = MBI()->get_number_entities_by_type( 0, MBTRI, orig_n_tris );
@@ -1778,7 +1778,7 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
               << " curves, and " << orig_n_tris << " triangles" << std::endl;  
     }
     
-    if(verbose) std::cout << "Finding degenerate triangles " << std::endl;
+    if(verbose) std::cout << "Finding degenerate triangles... " << std::endl;
     result = find_degenerate_tris();
     if(gen::error(result!=MB_SUCCESS,"could not determine if triangles were degenerate or not")) return result;
       

--- a/make_watertight/mw_func.cpp
+++ b/make_watertight/mw_func.cpp
@@ -645,7 +645,7 @@ MBErrorCode seal_arc_pair( const bool debug,
 	  std::cout << "  warning6: surf " << surf_id << " vertex move_dist=" 
                     << move_dist << std::endl;
 	}
-	rval = zip::t_joint( normal_tag, edge[e_pos-1], edge[e_pos], skin[s_pos] );
+	rval = zip::t_joint( normal_tag, edge[e_pos-1], edge[e_pos], skin[s_pos], debug );
         if(gen::error(MB_SUCCESS!=rval,"tjoint failed a")) return rval;
 	skin.insert( skin.begin()+s_pos, edge[e_pos] );
 	e_pos++;
@@ -663,7 +663,7 @@ MBErrorCode seal_arc_pair( const bool debug,
 	  std::cout << "  warning6: surf " << surf_id << " vertex move_dist=" 
                     << move_dist << std::endl;
 	}
-	rval = zip::t_joint( normal_tag, edge[e_pos-1], skin[s_pos], edge[e_pos] );
+	rval = zip::t_joint( normal_tag, edge[e_pos-1], skin[s_pos], edge[e_pos], debug );
         if(gen::error(MB_SUCCESS!=rval,"tjoint failed b")) return rval;
 	edge.insert( edge.begin() + e_pos, skin[s_pos] );
 	e_pos++;

--- a/make_watertight/mw_func.cpp
+++ b/make_watertight/mw_func.cpp
@@ -36,38 +36,38 @@
 
 
 
-MBInterface *MOAB();
+moab::Interface *MOAB();
 
 namespace mw_func {
 
 
 
-MBErrorCode delete_all_edges() {
+moab::ErrorCode delete_all_edges() {
   // delete all of the edges. Never keep edges. They are too hard to track and use
   // due to orientation and multiple entities errors when merging.
-  MBErrorCode result;
-  MBRange edges;
-  result = MBI()->get_entities_by_type( 0, MBEDGE, edges );
-  if(gen::error(MB_SUCCESS!=result,"could not get edges")) return result;
-  assert(MB_SUCCESS == result);
+  moab::ErrorCode result;
+  moab::Range edges;
+  result = MBI()->get_entities_by_type( 0, moab::MBEDGE, edges );
+  if(gen::error(moab::MB_SUCCESS!=result,"could not get edges")) return result;
+  assert(moab::MB_SUCCESS == result);
   result = MBI()->delete_entities( edges );
-  if(gen::error(MB_SUCCESS!=result,"could not delete edges")) return result;
-  assert(MB_SUCCESS == result);
-  return MB_SUCCESS;
+  if(gen::error(moab::MB_SUCCESS!=result,"could not delete edges")) return result;
+  assert(moab::MB_SUCCESS == result);
+  return moab::MB_SUCCESS;
 }
 
-MBErrorCode find_degenerate_tris() {
-  MBErrorCode result;
-  MBRange tris;
-  result = MBI()->get_entities_by_type( 0, MBTRI, tris );
-  if(gen::error(MB_SUCCESS!=result,"could not get tris")) return result;
-  assert(MB_SUCCESS == result);
+moab::ErrorCode find_degenerate_tris() {
+  moab::ErrorCode result;
+  moab::Range tris;
+  result = MBI()->get_entities_by_type( 0, moab::MBTRI, tris );
+  if(gen::error(moab::MB_SUCCESS!=result,"could not get tris")) return result;
+  assert(moab::MB_SUCCESS == result);
   int counter = 0;
-  for(MBRange::const_iterator i=tris.begin(); i!=tris.end(); ++i) {
+  for(moab::Range::const_iterator i=tris.begin(); i!=tris.end(); ++i) {
     if( gen::triangle_degenerate(*i) ) {
       result = MBI()->list_entity(*i);
-      if(gen::error(MB_SUCCESS!=result,"found degenerate tri")) return result;
-      assert(MB_SUCCESS == result);
+      if(gen::error(moab::MB_SUCCESS!=result,"found degenerate tri")) return result;
+      assert(moab::MB_SUCCESS == result);
       ++counter;
     }
   }
@@ -75,32 +75,32 @@ MBErrorCode find_degenerate_tris() {
   {
   std::cout << "Found " << counter << " degenerate triangles. " << std::endl;
   }
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
 
 // Input: Possibly unordered sets of curves that do track ownership. Curves contain
 //        edges and vertices. Parents sets are surfaces. Child sets are endpoint
 //        vertices.
 // Output: Ordered sets of verts that do track ownership. All edges are deleted.
-MBErrorCode prepare_curves(MBRange &curve_sets, 
-                           MBTag geom_tag, MBTag id_tag, MBTag merge_tag, 
+moab::ErrorCode prepare_curves(moab::Range &curve_sets, 
+                           moab::Tag geom_tag, moab::Tag id_tag, moab::Tag merge_tag, 
                            const double FACET_TOL, const bool debug, bool verbose ) {
-  MBErrorCode result;
+  moab::ErrorCode result;
   if (verbose) std::cout << "Modifying faceted curve representation and removing small curves..." 
             << std::endl;
 
   // process each curve
-  for(MBRange::iterator i=curve_sets.begin(); i!=curve_sets.end(); i++ ) {
+  for(moab::Range::iterator i=curve_sets.begin(); i!=curve_sets.end(); i++ ) {
     // get the curve id of the curve meshset
     int id;
     result = MBI()->tag_get_data( id_tag, &(*i), 1, &id );
-    if(gen::error(MB_SUCCESS!=result,"could not get id tag")) return result;
+    if(gen::error(moab::MB_SUCCESS!=result,"could not get id tag")) return result;
     if(debug) std::cout << "curve " << id << std::endl;
 
     // get the range of edges of the curve meshset
-    std::vector<MBEntityHandle> curve_edges;
-    result = MBI()->get_entities_by_type( *i, MBEDGE, curve_edges );
-    if(gen::error(MB_SUCCESS!=result,"could not get curve_edges")) return result;
+    std::vector<moab::EntityHandle> curve_edges;
+    result = MBI()->get_entities_by_type( *i, moab::MBEDGE, curve_edges );
+    if(gen::error(moab::MB_SUCCESS!=result,"could not get curve_edges")) return result;
 
     /* Merge the endpoints of the curve and remove its edges if it is too small.
     Use the MERGE_TOL because these edges will be merged with the MERGE_TOL 
@@ -113,9 +113,9 @@ MBErrorCode prepare_curves(MBRange &curve_sets,
           << " cm, n_verts=" << curve_edges.size()+1 << std::endl;
         }
       // get the endpoints of the curve
-      MBRange endpt_sets;
+      moab::Range endpt_sets;
       result = MBI()->get_child_meshsets( *i, endpt_sets );
-      if(gen::error(MB_SUCCESS!=result,"could not get curve child sets")) return result;
+      if(gen::error(moab::MB_SUCCESS!=result,"could not get curve child sets")) return result;
 
       if(endpt_sets.empty()) {
         if(gen::error(true,"curve has no child sets")) return result;
@@ -123,44 +123,44 @@ MBErrorCode prepare_curves(MBRange &curve_sets,
         // The edges are no longer needed. Remove them before altering the range
         // by deleting degenerate edges below.
         result = MBI()->delete_entities( &curve_edges[0], curve_edges.size() );
-        if(gen::error(MB_SUCCESS!=result,"could not delete edges")) return result;
+        if(gen::error(moab::MB_SUCCESS!=result,"could not delete edges")) return result;
 
       } else if(2 == endpt_sets.size()) {
         // The edges are no longer needed. Remove them before altering the range
         // by deleting degenerate edges below.
         result = MBI()->delete_entities( &curve_edges[0], curve_edges.size() );
-        if(gen::error(MB_SUCCESS!=result,"could not delete edges")) return result;
+        if(gen::error(moab::MB_SUCCESS!=result,"could not delete edges")) return result;
 
-        MBRange front_endpt, back_endpt;
-        result = MBI()->get_entities_by_type( endpt_sets.front(), MBVERTEX, front_endpt);
-        if(gen::error(MB_SUCCESS!=result,"could not get vert from front endpt set")) return result;
+        moab::Range front_endpt, back_endpt;
+        result = MBI()->get_entities_by_type( endpt_sets.front(), moab::MBVERTEX, front_endpt);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not get vert from front endpt set")) return result;
         if(gen::error(1!=front_endpt.size(),"front endpt set does not have 1 vert")) return result;
 
-        result = MBI()->get_entities_by_type( endpt_sets.back(), MBVERTEX, back_endpt);
-        if(gen::error(MB_SUCCESS!=result,"could not get vert from back endpt set")) return result;
+        result = MBI()->get_entities_by_type( endpt_sets.back(), moab::MBVERTEX, back_endpt);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not get vert from back endpt set")) return result;
         if(gen::error(1!=back_endpt.size(),"back endpt set does not have 1 vert")) return result;
 
         // merge the endpoints-ALWAYS CHECK TO AVOID MERGING THE SAME ENTITY!!!
         if(front_endpt[0] != back_endpt[0]) {
-	  std::vector<MBEntityHandle> temp;
+	  std::vector<moab::EntityHandle> temp;
           result = zip::merge_verts( front_endpt.front(), back_endpt.front(), temp, temp );
-          if(gen::error(MB_SUCCESS!=result,"could not merge verts")) return result;
+          if(gen::error(moab::MB_SUCCESS!=result,"could not merge verts")) return result;
 
           // check for and remove degenerate edges caused by the merge
-          MBRange edges;
-          MBEntityHandle temp_pt = front_endpt[0];
+          moab::Range edges;
+          moab::EntityHandle temp_pt = front_endpt[0];
           result = MBI()->get_adjacencies( &temp_pt, 1, 1, false, edges);
-          if(gen::error(MB_SUCCESS!=result,"could not get adj edges")) return result;
+          if(gen::error(moab::MB_SUCCESS!=result,"could not get adj edges")) return result;
 
-          for(MBRange::iterator j=edges.begin(); j!=edges.end(); j++) {
-            const MBEntityHandle *conn;
+          for(moab::Range::iterator j=edges.begin(); j!=edges.end(); j++) {
+            const moab::EntityHandle *conn;
             int n_verts;
             result = MBI()->get_connectivity( *j, conn, n_verts); 
-            if(gen::error(MB_SUCCESS!=result,"could not get edge conn")) return result;
+            if(gen::error(moab::MB_SUCCESS!=result,"could not get edge conn")) return result;
 
             if(conn[0] == conn[1]) {
               result = MBI()->delete_entities( &(*j), 1 );
-              if(gen::error(MB_SUCCESS!=result,"could not delete degenerate edge")) return result;
+              if(gen::error(moab::MB_SUCCESS!=result,"could not delete degenerate edge")) return result;
             }
           }
 	}
@@ -172,31 +172,31 @@ MBErrorCode prepare_curves(MBRange &curve_sets,
 
       // Remove the curve set. This also removes parent-child relationships.
       result = MBI()->delete_entities( &(*i), 1);
-      if(gen::error(MB_SUCCESS!=result,"could not delete curve set")) return result;
+      if(gen::error(moab::MB_SUCCESS!=result,"could not delete curve set")) return result;
       i = curve_sets.erase(i) - 1;
     } else {
 
       // convert the curve of edges into a curve of verts 
-      std::vector<MBEntityHandle> ordered_verts;
+      std::vector<moab::EntityHandle> ordered_verts;
       result = gen::ordered_verts_from_ordered_edges( curve_edges, ordered_verts);
-      if(gen::error(MB_SUCCESS!=result,"could not order_verts_by_edge")) return result;
+      if(gen::error(moab::MB_SUCCESS!=result,"could not order_verts_by_edge")) return result;
 
       // replace the unordered edges with the ordered verts
       result = arc::set_meshset( *i, ordered_verts );
-      if(gen::error(MB_SUCCESS!=result,"could not set_meshset")) return result;
+      if(gen::error(moab::MB_SUCCESS!=result,"could not set_meshset")) return result;
       
       // The edges are no longer needed.
       result = MBI()->delete_entities( &curve_edges[0], curve_edges.size() );
-      if(gen::error(MB_SUCCESS!=result,"could not delete edges")) return result;
+      if(gen::error(moab::MB_SUCCESS!=result,"could not delete edges")) return result;
     }
   }
 
   // merge curves that are the same within facet_tol 
   if (verbose) std::cout << "Identifying coincident curves to be merged..." << std::endl;
   result = arc::merge_curves(curve_sets, FACET_TOL, id_tag, merge_tag, debug );
-  if(gen::error(MB_SUCCESS!=result,"could not merge_curves")) return result;
+  if(gen::error(moab::MB_SUCCESS!=result,"could not merge_curves")) return result;
 
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
 
 /* The chosen curve may need to be reversed to be in the same direction as the skin.
@@ -208,21 +208,21 @@ MBErrorCode prepare_curves(MBRange &curve_sets,
 /// Cut an arc out of the skin. Return a corresponding curve, the curve's set, and
 /// is the curve has ben reversed. The returned skin has the arc cut away. The
 /// returned vector of curve sets has the curve removed.
-MBErrorCode create_arc_pair(  const double FACET_TOL,
-                              const MBEntityHandle surf_set,
-			      std::vector<MBEntityHandle> &skin_loop,
-			      std::vector<MBEntityHandle> &curve_sets,
-			      const MBEntityHandle front_endpt,
+moab::ErrorCode create_arc_pair(  const double FACET_TOL,
+                              const moab::EntityHandle surf_set,
+			      std::vector<moab::EntityHandle> &skin_loop,
+			      std::vector<moab::EntityHandle> &curve_sets,
+			      const moab::EntityHandle front_endpt,
                               const bool debug,
-			      MBEntityHandle &curve_set,
+			      moab::EntityHandle &curve_set,
 			      bool &curve_is_reversed,
-			      std::vector<MBEntityHandle> &curve,
-			      std::vector<MBEntityHandle> &skin_arc ) {
+			      std::vector<moab::EntityHandle> &curve,
+			      std::vector<moab::EntityHandle> &skin_arc ) {
 
   /* Now we have a topological connection between the curve and skin. Find other
      curves that share this vert. Be aware if the curve is reversed so the
      original direction can be preserved when done zipping. */
-  MBErrorCode rval;
+  moab::ErrorCode rval;
   if(debug) {
     std::cout << curve_sets.size() << " curves remain to be zipped" 
               << " skin_loop.size()=" << skin_loop.size() << " front_endpt="
@@ -241,18 +241,18 @@ MBErrorCode create_arc_pair(  const double FACET_TOL,
   // Compare all curves, keeping the best pair
   for(unsigned i=0; i<curve_sets.size(); ++i) {
     // get geometric vertex sets
-    MBRange endpt_sets;
+    moab::Range endpt_sets;
     rval = MBI()->get_child_meshsets(curve_sets[i], endpt_sets );
-    if(gen::error(MB_SUCCESS!=rval,"could not get endpt_sets")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"could not get endpt_sets")) return rval;
     if(gen::error(endpt_sets.empty() || 2<endpt_sets.size(),
-                  "too many endpt_sets")) return MB_FAILURE;
+                  "too many endpt_sets")) return moab::MB_FAILURE;
     // get the vertex handles
-    std::vector<MBEntityHandle> endpts;
+    std::vector<moab::EntityHandle> endpts;
     for(unsigned j=0; j<endpt_sets.size(); ++j) {
-      MBRange endpt;
-      rval = MBI()->get_entities_by_type( endpt_sets[j], MBVERTEX, endpt );
-      if(gen::error(MB_SUCCESS!=rval,"could not get endpt")) return rval;
-      if(gen::error(1!=endpt.size(),"not one endpt")) return MB_FAILURE;
+      moab::Range endpt;
+      rval = MBI()->get_entities_by_type( endpt_sets[j], moab::MBVERTEX, endpt );
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get endpt")) return rval;
+      if(gen::error(1!=endpt.size(),"not one endpt")) return moab::MB_FAILURE;
       endpts.push_back( endpt.front() );
       if(debug) std::cout << "curve " << gen::geom_id_by_handle(curve_sets[i]) 
                           << " endpt=" << endpt.front() << std::endl;
@@ -262,10 +262,10 @@ MBErrorCode create_arc_pair(  const double FACET_TOL,
     if(front_endpt!=endpts.front() && front_endpt!=endpts.back()) continue;
 
     // get the point representation
-    std::vector<MBEntityHandle> temp_curve;
+    std::vector<moab::EntityHandle> temp_curve;
     rval = arc::get_meshset( curve_sets[i], temp_curve );
-    if(gen::error(MB_SUCCESS!=rval,"could not get curve set")) return rval;
-    //if(gen::error(2>temp_curve.size(),"curve is degenerate")) return MB_FAILURE;
+    if(gen::error(moab::MB_SUCCESS!=rval,"could not get curve set")) return rval;
+    //if(gen::error(2>temp_curve.size(),"curve is degenerate")) return moab::MB_FAILURE;
     if(2>temp_curve.size()) std::cout << "warning11: curve is degenerate" << std::endl;
     if(debug) {
       std::cout << "  adj curve " << gen::geom_id_by_handle(curve_sets[i]) << ":" << std::endl; 
@@ -281,7 +281,7 @@ MBErrorCode create_arc_pair(  const double FACET_TOL,
     std::cout << "curve_set = " << gen::geom_id_by_handle(curve_sets[i]) << std::endl;
     }
     rval = gen::get_curve_surf_sense( surf_set, curve_sets[i], sense );
-    if(gen::error(MB_SUCCESS!=rval,"could not get_curve_surf_sense")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"could not get_curve_surf_sense")) return rval;
 
     // get the curve length, for efficient find_closest_vert, plus a tolerance.
     // This also helps to find the correct skin arc in special (~1D surfs) cases
@@ -300,17 +300,17 @@ MBErrorCode create_arc_pair(  const double FACET_TOL,
         pos = skin_loop.size()-1;
       } else {
         rval = gen::find_closest_vert( temp_curve.back(), skin_loop, pos, temp_curve_len+extra );
-        if(gen::error(MB_SUCCESS!=rval,"could not find_closest_vert")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"could not find_closest_vert")) return rval;
       }
       if(debug) std::cout << "  end of skin arc=" << skin_loop[pos] << std::endl; 
       // SPECIAL CASE: If the skin is a circle, create an arc out of the circle
       if(skin_loop[pos] == skin_loop.front()) pos = skin_loop.size()-1;
 
       // create a skin arc to test against the curve
-      std::vector<MBEntityHandle> temp_skin(skin_loop.begin(), skin_loop.begin()+pos+1); 
+      std::vector<moab::EntityHandle> temp_skin(skin_loop.begin(), skin_loop.begin()+pos+1); 
       double d;
       rval = gen::dist_between_arcs( debug, temp_skin, temp_curve, d );
-      if(gen::error(MB_SUCCESS!=rval,"could not get dist_between_arcs")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get dist_between_arcs")) return rval;
       if(debug) std::cout << " curve-skin dist=" << d << std::endl;
  
       // if less than the min_dist, this curve is the best (thus far)
@@ -335,17 +335,17 @@ MBErrorCode create_arc_pair(  const double FACET_TOL,
         pos = skin_loop.size()-1;
       } else {
         rval = gen::find_closest_vert( temp_curve.back(), skin_loop, pos, temp_curve_len+extra );
-        if(gen::error(MB_SUCCESS!=rval,"could not find_closest_vert")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"could not find_closest_vert")) return rval;
       }
       if(debug) std::cout << "  end of skin arc=" << skin_loop[pos] << std::endl; 
       // SPECIAL CASE: If the skin is a circle, create an arc out of the circle
       if(skin_loop[pos] == skin_loop.front()) pos = skin_loop.size()-1;
 
       // create a skin arc to test against the curve
-      std::vector<MBEntityHandle> temp_skin(skin_loop.begin(), skin_loop.begin()+pos+1); 
+      std::vector<moab::EntityHandle> temp_skin(skin_loop.begin(), skin_loop.begin()+pos+1); 
       double d;
       rval = gen::dist_between_arcs( debug, temp_skin, temp_curve, d );
-      if(gen::error(MB_SUCCESS!=rval,"could not get dist_between_arcs")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get dist_between_arcs")) return rval;
       if(debug) std::cout << " curve-skin dist=" << d << std::endl;
 
       // if less than the min_dist, this curve is the best (thus far)
@@ -368,14 +368,14 @@ MBErrorCode create_arc_pair(  const double FACET_TOL,
       std::cout << "  curve " << gen::geom_id_by_handle(curve_sets[i]) 
                 << " is unsealed" << std::endl;
     }
-    return MB_FAILURE;
+    return moab::MB_FAILURE;
   }
 
   // If the average distance between the closest skin and curve is too far...
   if(100*FACET_TOL<=min_dist) {
     std::cout << "  warning8: curve too far from skin, average_dist=" 
               << min_dist << std::endl;
-    if(1.0<=min_dist) return MB_FAILURE;
+    if(1.0<=min_dist) return moab::MB_FAILURE;
   }
      
   // remove the chosen curve the set of unsealed curves
@@ -391,7 +391,7 @@ MBErrorCode create_arc_pair(  const double FACET_TOL,
 
   if(debug) std::cout << "  curve " << gen::geom_id_by_handle(curve_set) 
                       << " paired with skin, min_dist =" << min_dist << std::endl;
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
 
 
@@ -403,11 +403,11 @@ MBErrorCode create_arc_pair(  const double FACET_TOL,
 //  -Instead of altering the skin and curve vectors, make them const. Put the
 // sealed curve in a new vector, using only push_back. This
 // would avoid all of the really slow inserts and erases in the curve and skin vectors.
-MBErrorCode seal_arc_pair( const bool debug,
+moab::ErrorCode seal_arc_pair( const bool debug,
                            const double FACET_TOL,
-                           const MBTag normal_tag,
-                           std::vector<MBEntityHandle> &edge, /* in */
-                           std::vector<MBEntityHandle> &skin /* in/out */,
+                           const moab::Tag normal_tag,
+                           std::vector<moab::EntityHandle> &edge, /* in */
+                           std::vector<moab::EntityHandle> &skin /* in/out */,
                            const int surf_id ) {
   if(debug) {
     std::cout << "edge before sealing:" << std::endl;
@@ -416,22 +416,22 @@ MBErrorCode seal_arc_pair( const bool debug,
     gen::print_loop(skin);
    }
 
-  MBErrorCode rval;
+  moab::ErrorCode rval;
   const double TOL_SQR = FACET_TOL*FACET_TOL;
   if(gen::error(edge.empty() || skin.empty(),"edge or skin has no verts")) 
-    return MB_FAILURE;
+    return moab::MB_FAILURE;
 
 
   //**************************************************************************
   // Merge the front of the skin to the front of the curve
   //**************************************************************************
   {
-    MBEntityHandle keep_vert   = edge.front();
-    MBEntityHandle delete_vert = skin.front();
+    moab::EntityHandle keep_vert   = edge.front();
+    moab::EntityHandle delete_vert = skin.front();
     if(keep_vert != delete_vert) {
       double merge_dist;
       rval = gen::dist_between_verts( keep_vert, delete_vert, merge_dist );
-      if(gen::error(MB_SUCCESS!=rval,"could not get merge_dist g")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get merge_dist g")) return rval;
       if(debug) {
 	std::cout << "  merged skin_vert=" << delete_vert << " to edge_vert=" << keep_vert
 		  << " merge_dist=" << merge_dist << std::endl;
@@ -440,7 +440,7 @@ MBErrorCode seal_arc_pair( const bool debug,
 	std::cout << "  warning0: front pt merge_dist=" << merge_dist << std::endl;
       }  
       rval = zip::merge_verts( keep_vert, delete_vert, skin, edge );
-      if(gen::error(MB_SUCCESS!=rval,"could not merge verts g")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not merge verts g")) return rval;
     }
   }
 
@@ -448,12 +448,12 @@ MBErrorCode seal_arc_pair( const bool debug,
   // Merge the back of the skin to the back of the curve
   //**************************************************************************
   {
-    MBEntityHandle keep_vert   = edge.back();
-    MBEntityHandle delete_vert = skin.back();
+    moab::EntityHandle keep_vert   = edge.back();
+    moab::EntityHandle delete_vert = skin.back();
     if(keep_vert != delete_vert) {
       double merge_dist;
       rval = gen::dist_between_verts( keep_vert, delete_vert, merge_dist );
-      if(gen::error(MB_SUCCESS!=rval,"could not get merge_dist h")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get merge_dist h")) return rval;
       if(debug) {
 	std::cout << "  merged skin_vert=" << delete_vert << " to edge_vert=" << keep_vert
 		  << " merge_dist=" << merge_dist << std::endl;
@@ -461,10 +461,10 @@ MBErrorCode seal_arc_pair( const bool debug,
       if(FACET_TOL < merge_dist) {
 	std::cout << "  warning0: surf " << surf_id << " back pt merge_dist=" 
                   << merge_dist << std::endl;
-        if(1000*FACET_TOL < merge_dist) return MB_FAILURE;
+        if(1000*FACET_TOL < merge_dist) return moab::MB_FAILURE;
       }  
       rval = zip::merge_verts( keep_vert, delete_vert, skin, edge );
-      if(gen::error(MB_SUCCESS!=rval,"could not merge verts g")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not merge verts g")) return rval;
     }
   }
 
@@ -481,9 +481,9 @@ MBErrorCode seal_arc_pair( const bool debug,
     if(e_pos==edge.size() || s_pos==skin.size()) break;
 
     rval = gen::squared_dist_between_verts( edge[e_pos-1], edge[e_pos], e_dist );
-    if(gen::error(MB_SUCCESS!=rval,"could not get e_dist")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"could not get e_dist")) return rval;
     rval = gen::squared_dist_between_verts( edge[e_pos-1], skin[s_pos], s_dist );
-    if(gen::error(MB_SUCCESS!=rval,"could not get s_dist")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"could not get s_dist")) return rval;
     if(debug) {
       std::cout << " e_pos=" << e_pos << " e_dist=" 
 		<< e_dist << " vert=" << edge[e_pos] << " size="
@@ -499,15 +499,15 @@ MBErrorCode seal_arc_pair( const bool debug,
       edge_is_next = false;
       double move_dist;
       rval = gen::line_point_dist( edge[e_pos-1], edge[e_pos], skin[s_pos], move_dist );
-      if(gen::error(MB_SUCCESS!=rval,"could not get line_point_dist")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get line_point_dist")) return rval;
       if(10*FACET_TOL < move_dist) {
 	std::cout << "  warning5: surf " << surf_id << " vertex move_dist=" 
                   << move_dist << std::endl;
       }
       rval = gen::point_line_projection( edge[e_pos-1], edge[e_pos], skin[s_pos]);
-      if(gen::error(MB_SUCCESS!=rval,"could not get point_line_projection")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get point_line_projection")) return rval;
       rval = gen::squared_dist_between_verts( edge[e_pos-1], skin[s_pos], s_dist );
-      if(gen::error(MB_SUCCESS!=rval,"could not get s_dist b")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get s_dist b")) return rval;
       dist = s_dist;
       if(debug) std::cout << "skin is next, projected dist=" << dist << std::endl;
     } else {
@@ -518,42 +518,42 @@ MBErrorCode seal_arc_pair( const bool debug,
 
     // find the cs_dist after moving the skin to the curve (if skin_is_next)
     rval = gen::squared_dist_between_verts( edge[e_pos], skin[s_pos], es_dist );
-    if(gen::error(MB_SUCCESS!=rval,"could not get es_dist")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"could not get es_dist")) return rval;
   
     // **************************************************************************
     // Merge with previous vert if it is too close
     // **************************************************************************
     if(dist < TOL_SQR) {
-      MBEntityHandle keep_vert = edge[e_pos-1];
+      moab::EntityHandle keep_vert = edge[e_pos-1];
       if(edge_is_next) {
-	MBEntityHandle delete_vert = edge[e_pos];
+	moab::EntityHandle delete_vert = edge[e_pos];
 	if(keep_vert != delete_vert) { // cannot merge the same vert
 	  if(debug) {
 	    double merge_dist;
             rval = gen::dist_between_verts( keep_vert, delete_vert, merge_dist );
-            if(gen::error(MB_SUCCESS!=rval,"could not get merge_dist")) return rval;
+            if(gen::error(moab::MB_SUCCESS!=rval,"could not get merge_dist")) return rval;
 	    std::cout << "  merged edge_vert=" << delete_vert << " to edge_vert=" 
 		      << keep_vert << " merge_dist=" << merge_dist <<std::endl;
 	  }  
 	  rval = zip::merge_verts( keep_vert, delete_vert, skin, edge );
-          if(gen::error(MB_SUCCESS!=rval,"could not merge_verts a")) return rval;
+          if(gen::error(moab::MB_SUCCESS!=rval,"could not merge_verts a")) return rval;
 	}
 	if(edge.size() < e_pos+1) {
 	  std::cout << "edge.size()=" << edge.size() << " e_pos=" << e_pos << std::endl;
 	}
 	edge.erase( edge.begin() + e_pos );
       } else {
-	MBEntityHandle delete_vert = skin[s_pos];
+	moab::EntityHandle delete_vert = skin[s_pos];
 	if(keep_vert != delete_vert) {
 	  if(debug) {
 	    double merge_dist;
             rval  = gen::dist_between_verts( keep_vert, delete_vert, merge_dist );
-            if(gen::error(MB_SUCCESS!=rval,"could not get merge_dist b")) return rval;
+            if(gen::error(moab::MB_SUCCESS!=rval,"could not get merge_dist b")) return rval;
 	    std::cout << "  merged skin_vert=" << delete_vert << " to edge_vert=" 
 		      << keep_vert << " merge_dist=" << merge_dist << std::endl;  
 	  } 
 	  rval = zip::merge_verts( keep_vert, delete_vert, skin, edge );
-          if(gen::error(MB_SUCCESS!=rval,"could not merge_verts b")) return rval;
+          if(gen::error(moab::MB_SUCCESS!=rval,"could not merge_verts b")) return rval;
 	}
 	if(skin.size() < s_pos+1) {
 	  std::cout << "skin.size()=" << skin.size() << " s_pos=" << s_pos << std::endl;
@@ -570,18 +570,18 @@ MBErrorCode seal_arc_pair( const bool debug,
       //} else if(FACET_TOL > fabs(c_dist-s_dist)) {
     } else if(TOL_SQR > es_dist) {
       // merge the verts if they are not the same
-      MBEntityHandle keep_vert  = edge[e_pos];
+      moab::EntityHandle keep_vert  = edge[e_pos];
       if(skin[s_pos] != keep_vert) {
-	MBEntityHandle delete_vert= skin[s_pos]; 
+	moab::EntityHandle delete_vert= skin[s_pos]; 
 	if(debug) {
 	  double merge_dist;
           rval  = gen::dist_between_verts( keep_vert, delete_vert, merge_dist );
-          if(gen::error(MB_SUCCESS!=rval,"could not get merge_dist c")) return rval;
+          if(gen::error(moab::MB_SUCCESS!=rval,"could not get merge_dist c")) return rval;
 	  std::cout << "  merged skin_vert=" << delete_vert << " to edge_vert=" 
 		    << keep_vert << " merge_dist=" << merge_dist << std::endl;
 	}
 	rval = zip::merge_verts( keep_vert, delete_vert, skin, edge );
-        if(gen::error(MB_SUCCESS!=rval,"could not merge_verts b")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"could not merge_verts b")) return rval;
       }
       s_pos++;
       e_pos++;
@@ -590,10 +590,10 @@ MBErrorCode seal_arc_pair( const bool debug,
 	// check to see if skin still exists
 	if(s_pos == skin.size()) break;
 	// check if the distance is less than merge tol
-	MBEntityHandle delete_vert= skin[s_pos]; 
+	moab::EntityHandle delete_vert= skin[s_pos]; 
 	double merge_dist;
         rval = gen::dist_between_verts( keep_vert, delete_vert, merge_dist); 
-        if(gen::error(MB_SUCCESS!=rval,"could not get merge_dist d")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"could not get merge_dist d")) return rval;
 	if(FACET_TOL < merge_dist) break;
 	// merge the verts if they are not the same
 	if(keep_vert != delete_vert) {
@@ -602,7 +602,7 @@ MBErrorCode seal_arc_pair( const bool debug,
 		      << keep_vert << " merge_dist=" << merge_dist << std::endl;
 	  }
 	  rval = zip::merge_verts( keep_vert, delete_vert, skin, edge );
-          if(gen::error(MB_SUCCESS!=rval,"could not merge_verts d")) return rval;
+          if(gen::error(moab::MB_SUCCESS!=rval,"could not merge_verts d")) return rval;
 	}
 	skin.erase( skin.begin() + s_pos );      
       }
@@ -611,10 +611,10 @@ MBErrorCode seal_arc_pair( const bool debug,
 	// check to see if curve still exists
 	if(e_pos == edge.size()) break;
 	// check if the distance is less than merge tol
-	MBEntityHandle delete_vert= edge[e_pos]; 
+	moab::EntityHandle delete_vert= edge[e_pos]; 
 	double merge_dist;
         rval = gen::dist_between_verts( keep_vert, delete_vert, merge_dist ); 
-        if(gen::error(MB_SUCCESS!=rval,"could not get merge_dist e")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"could not get merge_dist e")) return rval;
 	if(FACET_TOL < merge_dist) break;
 	// merge the verts if they are not the same
 	if(keep_vert != delete_vert) {
@@ -623,7 +623,7 @@ MBErrorCode seal_arc_pair( const bool debug,
 		      << keep_vert << " merge_dist=" << merge_dist << std::endl;
 	  }
 	  rval = zip::merge_verts( keep_vert, delete_vert, skin, edge );
-          if(gen::error(MB_SUCCESS!=rval,"could not merge_verts e")) return rval;
+          if(gen::error(moab::MB_SUCCESS!=rval,"could not merge_verts e")) return rval;
 	}
 	edge.erase( edge.begin() + e_pos );
       }
@@ -640,13 +640,13 @@ MBErrorCode seal_arc_pair( const bool debug,
 	}
 	double move_dist;
 	rval = gen::line_point_dist( edge[e_pos-1], skin[s_pos], edge[e_pos], move_dist );
-	if(gen::error(MB_SUCCESS!=rval,"could not get line_point_dist")) return rval;
+	if(gen::error(moab::MB_SUCCESS!=rval,"could not get line_point_dist")) return rval;
 	if(10*FACET_TOL < move_dist) {
 	  std::cout << "  warning6: surf " << surf_id << " vertex move_dist=" 
                     << move_dist << std::endl;
 	}
 	rval = zip::t_joint( normal_tag, edge[e_pos-1], edge[e_pos], skin[s_pos], debug );
-        if(gen::error(MB_SUCCESS!=rval,"tjoint failed a")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"tjoint failed a")) return rval;
 	skin.insert( skin.begin()+s_pos, edge[e_pos] );
 	e_pos++;
 	s_pos++;
@@ -658,13 +658,13 @@ MBErrorCode seal_arc_pair( const bool debug,
 	}
         double move_dist;
 	rval = gen::line_point_dist( edge[e_pos-1], edge[e_pos], skin[s_pos], move_dist );
-	if(gen::error(MB_SUCCESS!=rval,"could not get line_point_dist")) return rval;
+	if(gen::error(moab::MB_SUCCESS!=rval,"could not get line_point_dist")) return rval;
 	if(10*FACET_TOL < move_dist) {
 	  std::cout << "  warning6: surf " << surf_id << " vertex move_dist=" 
                     << move_dist << std::endl;
 	}
 	rval = zip::t_joint( normal_tag, edge[e_pos-1], skin[s_pos], edge[e_pos], debug );
-        if(gen::error(MB_SUCCESS!=rval,"tjoint failed b")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"tjoint failed b")) return rval;
 	edge.insert( edge.begin() + e_pos, skin[s_pos] );
 	e_pos++;
 	s_pos++;
@@ -679,7 +679,7 @@ MBErrorCode seal_arc_pair( const bool debug,
     if(2 <= e_pos) {
       double d;
       rval = gen::squared_dist_between_verts( edge[e_pos-1], edge[e_pos-2], d );
-      if(gen::error(MB_SUCCESS!=rval,"could not get dist")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get dist")) return rval;
       if(TOL_SQR > d) { 
 	std::cout << "zip_loop: d=" << d << std::endl;
 	gen::print_vertex_coords(edge[e_pos-1]);
@@ -708,31 +708,31 @@ MBErrorCode seal_arc_pair( const bool debug,
       std::cout << "skin:" << std::endl;
       gen::print_loop(skin);
     }
-    //return MB_FAILURE;
+    //return moab::MB_FAILURE;
   }
 
   if(debug) {
-    std::vector< std::vector<MBEntityHandle> > temp;
+    std::vector< std::vector<moab::EntityHandle> > temp;
     temp.push_back(edge);
     temp.push_back(skin);
     rval = zip::test_zipping(FACET_TOL, temp);
-    if(gen::error(MB_SUCCESS!=rval,"sealing test failed")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"sealing test failed")) return rval;
   }
 
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 
 }
 
 /// seals the skin_loop to the closest curves in curve sets in a watertight fashion
-MBErrorCode seal_loop( bool debug,
+moab::ErrorCode seal_loop( bool debug,
                        const double FACET_TOL,
-                       const MBTag normal_tag,
-                       const MBTag orig_curve_tag,
-                       const MBEntityHandle surf_set,
-                       std::vector<MBEntityHandle> &curve_sets,
-                       std::vector<MBEntityHandle> &skin_loop,
+                       const moab::Tag normal_tag,
+                       const moab::Tag orig_curve_tag,
+                       const moab::EntityHandle surf_set,
+                       std::vector<moab::EntityHandle> &curve_sets,
+                       std::vector<moab::EntityHandle> &skin_loop,
                        bool verbose) {
-  MBErrorCode rval;
+  moab::ErrorCode rval;
   debug = false;
   // Find a curve that corresponds to the skin. Note that because there is more
   // than one skin loop, not all curves of the surface correspond to each skin
@@ -748,7 +748,7 @@ MBErrorCode seal_loop( bool debug,
     std::cout << "seal_loop: no curves are left, but skin remains" << std::endl;
     gen::print_loop(skin_loop);
     skin_loop.clear();
-    return MB_FAILURE;
+    return moab::MB_FAILURE;
   }
 
   //**************************************************************************
@@ -765,22 +765,22 @@ MBErrorCode seal_loop( bool debug,
      still exist even though their corresponding loop has been removed. Not all
      curves in this list will ever be zipped. Select a curve that can be zipped. */
     unsigned pos, curve_idx;
-    MBEntityHandle closest_skin_pt, closest_front_curve_endpt;
+    moab::EntityHandle closest_skin_pt, closest_front_curve_endpt;
     double min_dist = std::numeric_limits<double>::max();
     for(unsigned i=0; i<curve_sets.size(); ++i) {
       // get geometric vertices
-      MBRange endpt_sets;
+      moab::Range endpt_sets;
       rval = MBI()->get_child_meshsets(curve_sets[i], endpt_sets );
-      if(gen::error(MB_SUCCESS!=rval,"could not get endpt_sets")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get endpt_sets")) return rval;
       if(gen::error(endpt_sets.empty() || 2<endpt_sets.size(),
-                    "too many endpt_sets")) return MB_FAILURE;
+                    "too many endpt_sets")) return moab::MB_FAILURE;
 
-      std::vector<MBEntityHandle> endpts;
+      std::vector<moab::EntityHandle> endpts;
       for(unsigned j=0; j<endpt_sets.size(); ++j) {
-        MBRange endpt;
-        rval = MBI()->get_entities_by_type( endpt_sets[j], MBVERTEX, endpt );
-        if(gen::error(MB_SUCCESS!=rval,"could not get endpt")) return rval;
-        if(gen::error(1!=endpt.size(),"not one endpt")) return MB_FAILURE;
+        moab::Range endpt;
+        rval = MBI()->get_entities_by_type( endpt_sets[j], moab::MBVERTEX, endpt );
+        if(gen::error(moab::MB_SUCCESS!=rval,"could not get endpt")) return rval;
+        if(gen::error(1!=endpt.size(),"not one endpt")) return moab::MB_FAILURE;
         endpts.push_back( endpt.front() );
       }
 
@@ -793,20 +793,20 @@ MBErrorCode seal_loop( bool debug,
       }
       
       // check to ensure that geometric verts are the curve endpts
-      std::vector<MBEntityHandle> curve;
+      std::vector<moab::EntityHandle> curve;
       rval = arc::get_meshset( curve_sets[i], curve );
-      if(gen::error(MB_SUCCESS!=rval,"could not get_meshset")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get_meshset")) return rval;
       if(1==endpt_sets.size()) {
-        if(gen::error(curve.front()!=curve.back(),"endpt discrepancy")) return MB_FAILURE;
+        if(gen::error(curve.front()!=curve.back(),"endpt discrepancy")) return moab::MB_FAILURE;
         if(gen::error(curve.front()!=endpts.front(),
-          "geometric verts inconsistent with curve")) return MB_FAILURE;
+          "geometric verts inconsistent with curve")) return moab::MB_FAILURE;
       } else {
         if(curve.front()==curve.back()) 
           if(debug) std::cout << "  warning10: degenerate curve endpts" << std::endl;
         if(gen::error(curve.front()!=endpts.front() && curve.front()!=endpts.back(),
-		      "endpts not consistent")) return MB_FAILURE;
+		      "endpts not consistent")) return moab::MB_FAILURE;
         if(gen::error(curve.back()!=endpts.front() && curve.back()!=endpts.back(),
-		      "endpts not consistent")) return MB_FAILURE;
+		      "endpts not consistent")) return moab::MB_FAILURE;
       }
 
       // determine the orientation of the curve wrt the surf.
@@ -817,15 +817,15 @@ MBErrorCode seal_loop( bool debug,
       std::cout << "curve_set = " << gen::geom_id_by_handle(curve_sets[i]) << std::endl;
       }
       rval = gen::get_curve_surf_sense( surf_set, curve_sets[i], sense );  
-      if(gen::error(MB_SUCCESS!=rval,"could not get_curve_surf_sense")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not get_curve_surf_sense")) return rval;
       // select the front wrt the skin.
-      MBEntityHandle curve_endpt = (SENSE_FORWARD==sense) ? curve.front() : curve.back();
+      moab::EntityHandle curve_endpt = (SENSE_FORWARD==sense) ? curve.front() : curve.back();
 
       // find closest skin vert to front of curve
       std::vector<double> d;
       std::vector<unsigned> p;
       rval = gen::find_closest_vert( 0, curve_endpt, skin_loop, p, d);
-      if(gen::error(MB_SUCCESS!=rval,"could not find_closest_vert")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"could not find_closest_vert")) return rval;
       if(debug) std::cout << "zip_loop: loop-curve endpt dist=" << d.front() << " skin_vert="
                           << skin_loop[p.front()] << " curve="
                           << gen::geom_id_by_handle(curve_sets[i]) << " front_endpt="
@@ -839,7 +839,7 @@ MBErrorCode seal_loop( bool debug,
       }
     }
 
-    MBEntityHandle front_endpt = closest_front_curve_endpt;
+    moab::EntityHandle front_endpt = closest_front_curve_endpt;
 
     // The closest points should be within facet tolerance
     if(100*FACET_TOL<min_dist && verbose) {
@@ -848,10 +848,10 @@ MBErrorCode seal_loop( bool debug,
       if(true) {
 	std::cout << "  skin pt:" << std::endl;
         rval = MBI()->list_entity(closest_skin_pt);
-        if(gen::error(MB_SUCCESS!=rval,"error listing skin pt")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"error listing skin pt")) return rval;
 	std::cout << "  curve vert:" << std::endl;
         rval = MBI()->list_entity(front_endpt);
-        if(gen::error(MB_SUCCESS!=rval,"error listing curve_vert")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"error listing curve_vert")) return rval;
       }
       return rval;
     }
@@ -865,19 +865,19 @@ MBErrorCode seal_loop( bool debug,
 
     /* Take the skin loops and advance it such that our common point is at 
        location 0. Ensure that that both endpoints are the same. */
-    std::vector<MBEntityHandle> temp_loop;
+    std::vector<moab::EntityHandle> temp_loop;
     temp_loop.reserve(skin_loop.size());
-    std::vector<MBEntityHandle>::iterator j = temp_loop.begin();
-    std::vector<MBEntityHandle>::iterator k = skin_loop.begin();
+    std::vector<moab::EntityHandle>::iterator j = temp_loop.begin();
+    std::vector<moab::EntityHandle>::iterator k = skin_loop.begin();
     // Do not insert the back endpoint (avoid duplicate).   
     temp_loop.insert( j, k+pos, k+skin_loop.size()-1 );
     j = temp_loop.begin(); // j became invalid because temp_loop resized
     j += skin_loop.size() - pos - 1;
     temp_loop.insert( j, k, k+pos+1 );
-    if(gen::error(temp_loop.size()!=skin_loop.size(),"loop size not conserved")) return MB_FAILURE;
+    if(gen::error(temp_loop.size()!=skin_loop.size(),"loop size not conserved")) return moab::MB_FAILURE;
     assert(temp_loop.size() == skin_loop.size()); // same size
     if(gen::error(temp_loop[0]!=temp_loop[temp_loop.size()-1],
-      "loop endpts not continuous")) return MB_FAILURE;
+      "loop endpts not continuous")) return moab::MB_FAILURE;
     assert(temp_loop[0] == temp_loop[temp_loop.size()-1]); // same endpoint
     skin_loop = temp_loop;
     if(debug) {
@@ -887,9 +887,9 @@ MBErrorCode seal_loop( bool debug,
     // Create a set to store skin_loop so that handles are updated during merging.
     // This prevents stale handles, and avoids O(n) search through every handle in
     // the skin loop if manually updating the skin_loop vector.
-    MBEntityHandle skin_loop_set;
-    rval = MBI()->create_meshset( MESHSET_TRACK_OWNER|MESHSET_ORDERED, skin_loop_set );
-    if(gen::error(MB_SUCCESS!=rval,"creating skin_loop_set failed")) return rval;      
+    moab::EntityHandle skin_loop_set;
+    rval = MBI()->create_meshset( moab::MESHSET_TRACK_OWNER|moab::MESHSET_ORDERED, skin_loop_set );
+    if(gen::error(moab::MB_SUCCESS!=rval,"creating skin_loop_set failed")) return rval;      
 
     while(!skin_loop.empty()) {
       //**************************************************************************
@@ -899,37 +899,37 @@ MBErrorCode seal_loop( bool debug,
       //**************************************************************************
 
       bool curve_is_reversed;
-      MBEntityHandle curve_set;
-      std::vector<MBEntityHandle> curve, skin_arc;
+      moab::EntityHandle curve_set;
+      std::vector<moab::EntityHandle> curve, skin_arc;
       rval = create_arc_pair( FACET_TOL, surf_set, skin_loop, curve_sets, front_endpt,
 			      debug, curve_set, curve_is_reversed, curve, skin_arc );
-      if(gen::error(MB_SUCCESS!=rval,"  pair creation failed")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"  pair creation failed")) return rval;
 
       // Let moab store skin loop to avoid stale vert handles from merging.
       rval = arc::set_meshset( skin_loop_set, skin_loop );    
-      if(gen::error(MB_SUCCESS!=rval,"setting skin_loop_set failed")) return rval;      
+      if(gen::error(moab::MB_SUCCESS!=rval,"setting skin_loop_set failed")) return rval;      
 
       // The original faceted curves are never used. Instead they are replaced by
       // skin. This reduces the number of new triangles created.
       int orig_curve;
       rval = MBI()->tag_get_data( orig_curve_tag, &curve_set, 1, &orig_curve );
-      if(gen::error(MB_SUCCESS!=rval,"can't get tag")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"can't get tag")) return rval;
 
       // If the tag is non-zero, the facet edge has already been replaced.
       if(orig_curve) {
         // this tag is used to mark the edge as updated
         int false_int = 0;
         rval = MBI()->tag_set_data( orig_curve_tag, &curve_set, 1, &false_int );
-        if(gen::error(MB_SUCCESS!=rval,"can't set tag")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval,"can't set tag")) return rval;
 
         // merge new endpoints to old endpoints  
         if(curve.front()!=skin_arc.front()) {
           rval = zip::merge_verts( curve.front(), skin_arc.front(), curve, skin_arc );
-	  if(gen::error(MB_SUCCESS!=rval,"merge verts failed")) return rval;
+	  if(gen::error(moab::MB_SUCCESS!=rval,"merge verts failed")) return rval;
         }
         if(curve.back()!=skin_arc.back()) {
           rval = zip::merge_verts( curve.back(), skin_arc.back(), curve, skin_arc );
-	  if(gen::error(MB_SUCCESS!=rval,"merge verts failed")) return rval;
+	  if(gen::error(moab::MB_SUCCESS!=rval,"merge verts failed")) return rval;
         }
 
 	// replace the faceted edge with a skin arc
@@ -939,10 +939,10 @@ MBErrorCode seal_loop( bool debug,
 
       } else {
 	// seal the pair together
-	std::vector<MBEntityHandle> sealed_curve;
+	std::vector<moab::EntityHandle> sealed_curve;
 	rval = seal_arc_pair( debug, FACET_TOL, normal_tag, curve, skin_arc,
                               gen::geom_id_by_handle(surf_set) );
-        if(gen::error(MB_SUCCESS!=rval, "    can't seal pair")) return rval;
+        if(gen::error(moab::MB_SUCCESS!=rval, "    can't seal pair")) return rval;
       }
 
       // get new front_endpt to guide selection of next curve
@@ -953,79 +953,79 @@ MBErrorCode seal_loop( bool debug,
 
       // set the sealed edge
       rval = arc::set_meshset( curve_set, curve );    
-      if(gen::error(MB_SUCCESS!=rval,"setting curve set failed")) return rval;
+      if(gen::error(moab::MB_SUCCESS!=rval,"setting curve set failed")) return rval;
 
       // Get skin_loop to cut an arc from it
       rval = arc::get_meshset( skin_loop_set, skin_loop );    
-      if(gen::error(MB_SUCCESS!=rval,"getting skin_loop set failed")) return rval;      
+      if(gen::error(moab::MB_SUCCESS!=rval,"getting skin_loop set failed")) return rval;      
 
       
     }
 
     // The skin_loop_set is no longer needed.
     rval = MBI()->delete_entities( &skin_loop_set, 1 );
-    if(gen::error(MB_SUCCESS!=rval,"deleting skin_loop_set failed")) return rval;      
+    if(gen::error(moab::MB_SUCCESS!=rval,"deleting skin_loop_set failed")) return rval;      
 
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
   // input: surface sets, ordered curve sets,
   // output: skin arcs corresponding to curves are added to parent surface sets
-MBErrorCode prepare_surfaces(MBRange &surface_sets,
-                             MBTag geom_tag, MBTag id_tag, MBTag normal_tag, MBTag merge_tag,
-                             MBTag orig_curve_tag,
+moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
+                             moab::Tag geom_tag, moab::Tag id_tag, moab::Tag normal_tag, moab::Tag merge_tag,
+                             moab::Tag orig_curve_tag,
                              const double SME_RESABS_TOL, const double FACET_TOL, 
                              const bool debug, bool verbose) 
 {
    
-    MBErrorCode result;
+    moab::ErrorCode result;
     // loop over each surface meshset
-    for(MBRange::iterator i=surface_sets.begin(); i!=surface_sets.end(); i++ ) 
+    for(moab::Range::iterator i=surface_sets.begin(); i!=surface_sets.end(); i++ ) 
       {
 
 	// get the surf id of the surface meshset
 	int surf_id;
 	result = MBI()->tag_get_data( id_tag, &(*i), 1, &surf_id );
-	if(gen::error(MB_SUCCESS!=result,"could not get id tag")) return result;
-	assert(MB_SUCCESS == result);
+	if(gen::error(moab::MB_SUCCESS!=result,"could not get id tag")) return result;
+	assert(moab::MB_SUCCESS == result);
 	if(debug) std::cout << "  surf id= " << surf_id << std::endl;
 
 	// get the 2D entities in the surface set
-	MBRange dim2_ents;
+	moab::Range dim2_ents;
 	result = MBI()->get_entities_by_dimension( *i, 2, dim2_ents );
-	if(gen::error(MB_SUCCESS!=result,"could not get 3D entities")) return result;
-	assert(MB_SUCCESS == result);
+	if(gen::error(moab::MB_SUCCESS!=result,"could not get 3D entities")) return result;
+	assert(moab::MB_SUCCESS == result);
 
 	// get facets of the surface meshset
-	MBRange tris;
-	result = MBI()->get_entities_by_type( *i, MBTRI, tris );
-	if(gen::error(MB_SUCCESS!=result,"could not get tris")) return result;
-	assert(MB_SUCCESS == result);
+	moab::Range tris;
+	result = MBI()->get_entities_by_type( *i, moab::MBTRI, tris );
+	if(gen::error(moab::MB_SUCCESS!=result,"could not get tris")) return result;
+	assert(moab::MB_SUCCESS == result);
 
         // Remove any 2D entities that are not triangles. This is needed because
         // ReadCGM will add quads and polygons to the surface set. This code only
         // works with triangles.
-        MBRange not_tris = subtract( dim2_ents, tris );
+        moab::Range not_tris = subtract( dim2_ents, tris );
         if(!not_tris.empty()) {
         result = MBI()->delete_entities( not_tris );
-        if(gen::error(MB_SUCCESS!=result,"could not delete not_tris")) return result;
-        assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not delete not_tris")) return result;
+        assert(moab::MB_SUCCESS == result);
         std::cout << "  removed " << not_tris.size() 
                   << " 2D elements that were not triangles from surface " 
                   << surf_id << std::endl;
         }
 
         // Get the curves and determine the number of unmerged curves
-        std::vector<MBEntityHandle> curve_sets, unmerged_curve_sets;
+        std::vector<moab::EntityHandle> curve_sets, unmerged_curve_sets;
         result = get_unmerged_curves( *i , curve_sets, unmerged_curve_sets, merge_tag, verbose, debug);
-        if(gen::error(MB_SUCCESS!=result, " could not get the curves and unmerged curves" )) return result; 
+        if(gen::error(moab::MB_SUCCESS!=result, " could not get the curves and unmerged curves" )) return result; 
       
 
         // If all of the curves are merged, remove the surfaces facets.
         if(unmerged_curve_sets.empty()) {
        
           result = gen::delete_surface( *i , geom_tag, tris, surf_id, debug, verbose); 
-          if( gen::error(MB_SUCCESS!=result, "could not delete surface" )) return result;                                              
+          if( gen::error(moab::MB_SUCCESS!=result, "could not delete surface" )) return result;                                              
           // adjust iterator so *i is still the same surface
           i = surface_sets.erase(i) - 1;
           continue;
@@ -1033,52 +1033,52 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
 
         // combine merged curve's surface senses
         result = gen::combine_merged_curve_senses( curve_sets, merge_tag, debug );
-        if(gen::error(MB_SUCCESS!=result,"could not combine the merged curve sets")) return result;
+        if(gen::error(moab::MB_SUCCESS!=result,"could not combine the merged curve sets")) return result;
 
 
         // Save the normals of the facets. These will later be used to determine if 
         // the tri became inverted.
         result = gen::save_normals( tris, normal_tag );
-        if(gen::error(MB_SUCCESS!=result,"could not save_normals")) return result;
-        assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not save_normals")) return result;
+        assert(moab::MB_SUCCESS == result);
   
         // Check if edges exist
         int n_edges;
-        result = MBI()->get_number_entities_by_type(0, MBEDGE, n_edges );
-        if(gen::error(MB_SUCCESS!=result,"could not get number of edges")) return result;
-        assert(MB_SUCCESS == result);
+        result = MBI()->get_number_entities_by_type(0, moab::MBEDGE, n_edges );
+        if(gen::error(moab::MB_SUCCESS!=result,"could not get number of edges")) return result;
+        assert(moab::MB_SUCCESS == result);
         if(gen::error(0!=n_edges,"edges exist")) return result;
         assert(0 == n_edges); //*** Why can't we have edges? (Also, this assertion is never used)
 
         // get the range of skin edges from the range of facets
-        MBSkinner tool(MBI());
-        MBRange skin_edges, skin_edges2;
+	moab::Skinner tool(MBI());
+        moab::Range skin_edges, skin_edges2;
         if(tris.empty()) continue; // nothing to zip
         // The MOAB skinner is not used here currently as it doesn't allow
         // make_watertight to close loops. The local version of find_skin is used instead. 
         // This should be ok as the local find_skin fundtion should only be avoided when checking meshes for watertightness
         // to keep from altering the data set when checking. 
         result = tool.find_skin( 0, tris, 1, skin_edges, false);
-        if(gen::error(MB_SUCCESS!=result,"could not find_skin")) return result;
-        assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not find_skin")) return result;
+        assert(moab::MB_SUCCESS == result);
      
 
         // merge the vertices of the skin
         // BRANDON: For some reason cgm2moab does not do this? This was the 
         // problem with mod13 surf 881. Two skin verts were coincident. A tol=1e-10
         // found the verts, but tol=0 did not.
-        MBRange skin_verts;
+        moab::Range skin_verts;
         bool cont = false;
         result = merge_skin_verts( skin_verts, skin_edges, SME_RESABS_TOL, surf_id, cont, debug);
-        if(gen::error(MB_SUCCESS!=result,"could not merge the skin verts")) return result; 
+        if(gen::error(moab::MB_SUCCESS!=result,"could not merge the skin verts")) return result; 
         if(cont) continue;
 
 
         // take skin edges and create loops of vertices
-        std::vector < std::vector <MBEntityHandle> > skin;
+        std::vector < std::vector <moab::EntityHandle> > skin;
         cont = false;
         result = create_skin_vert_loops ( skin_edges, tris, skin , surf_id, cont, debug);
-        if(gen::error(MB_SUCCESS!=result, " could not create skin loops of vertices")) return result; 
+        if(gen::error(moab::MB_SUCCESS!=result, " could not create skin loops of vertices")) return result; 
         if(cont) continue;
 
 
@@ -1087,56 +1087,56 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
 // separate this part from prepare surfaces into make_mesh_watertight??
 
 
-        MBEntityHandle skin_loop_sets[skin.size()];
+        moab::EntityHandle skin_loop_sets[skin.size()];
         result = seal_surface_loops ( *i , skin_loop_sets , skin,  curve_sets, normal_tag, orig_curve_tag, FACET_TOL, surf_id, debug);
-        if(gen::error(MB_SUCCESS!=result,"could not seal the surface loops")) return result; 
+        if(gen::error(moab::MB_SUCCESS!=result,"could not seal the surface loops")) return result; 
 
     
         // Remove the sets of skin loops
         result = MBI()->delete_entities( &skin_loop_sets[0], skin.size() );
-        if(gen::error(MB_SUCCESS!=result,"failed to zip: deleting skin_loop_sets failed")) 
+        if(gen::error(moab::MB_SUCCESS!=result,"failed to zip: deleting skin_loop_sets failed")) 
         return result;
 
       } // loop over each surface
-      return MB_SUCCESS;
+      return moab::MB_SUCCESS;
     }
 
 
-MBErrorCode fix_normals(MBRange surface_sets, MBTag id_tag, MBTag normal_tag, const bool debug, const bool verbose) {
-    MBErrorCode result;
+moab::ErrorCode fix_normals(moab::Range surface_sets, moab::Tag id_tag, moab::Tag normal_tag, const bool debug, const bool verbose) {
+    moab::ErrorCode result;
     if(debug) std::cout<< "number of surfaces=" << surface_sets.size() << std::endl;
     int inverted_tri_counter = 0;
 
     // loop over each surface meshset
-    for(MBRange::iterator i=surface_sets.begin(); i!=surface_sets.end(); i++ ) {
+    for(moab::Range::iterator i=surface_sets.begin(); i!=surface_sets.end(); i++ ) {
 
       // get the surf id of the surface meshset
       int surf_id;
       result = MBI()->tag_get_data( id_tag, &(*i), 1, &surf_id );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       if(debug) std::cout << "fix_normals surf id=" << surf_id << std::endl;
 
       // get facets from the surface meshset
-      MBRange tris;
-      result = MBI()->get_entities_by_type( *i, MBTRI, tris );
-      assert(MB_SUCCESS == result);
+      moab::Range tris;
+      result = MBI()->get_entities_by_type( *i, moab::MBTRI, tris );
+      assert(moab::MB_SUCCESS == result);
 
       // get the normals, pre zipping
-      std::vector<MBCartVect> old_normals(tris.size()), new_normals(tris.size());
+      std::vector<moab::CartVect> old_normals(tris.size()), new_normals(tris.size());
       result = MBI()->tag_get_data( normal_tag, tris, &old_normals[0]);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
 
       // get the normals, post zipping
       result = gen::triangle_normals( tris, new_normals );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
 
       // test the normals, finding the inverted tris
       std::vector<int> inverted_tri_indices;
       result = zip::test_normals( old_normals, new_normals, inverted_tri_indices);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
 
       // insert the inverted tris into a range
-      MBRange inverted_tris;
+      moab::Range inverted_tris;
       for(unsigned int j=0; j<inverted_tri_indices.size(); j++) {
         inverted_tris.insert( tris[inverted_tri_indices[j]] );
         if(debug) gen::print_triangle( tris[inverted_tri_indices[j]], false );
@@ -1144,42 +1144,42 @@ MBErrorCode fix_normals(MBRange surface_sets, MBTag id_tag, MBTag normal_tag, co
 
       // do edges exist?
       int n_edges;
-      result = MBI()->get_number_entities_by_type( 0, MBEDGE, n_edges );
-      assert(MB_SUCCESS == result);
+      result = MBI()->get_number_entities_by_type( 0, moab::MBEDGE, n_edges );
+      assert(moab::MB_SUCCESS == result);
       assert(0 == n_edges); // *** Why can't we have edges?
   
       // fix the inverted tris
       inverted_tri_counter += inverted_tris.size();
       result = zip::remove_inverted_tris(normal_tag, inverted_tris, debug );
-      if(MB_SUCCESS != result) 
+      if(moab::MB_SUCCESS != result) 
         std::cout << "  failed to fix inverted triangles in surface " << surf_id << std::endl;
 
       // if fix_normals exits on an error, we still need to remove its edges
       result = delete_all_edges();
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
     }
     if(verbose)
     {
     std::cout << "  Before fixing, " << inverted_tri_counter 
               << " inverted triangles were found." << std::endl;
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode restore_moab_curve_representation( const MBRange curve_sets ) {
-    MBErrorCode result;
-    for(MBRange::const_iterator i=curve_sets.begin(); i!=curve_sets.end(); ++i) {
+  moab::ErrorCode restore_moab_curve_representation( const moab::Range curve_sets ) {
+    moab::ErrorCode result;
+    for(moab::Range::const_iterator i=curve_sets.begin(); i!=curve_sets.end(); ++i) {
       // get the ordered verts
-      std::vector<MBEntityHandle> ordered_verts;
+      std::vector<moab::EntityHandle> ordered_verts;
       result = arc::get_meshset( *i, ordered_verts );
-      assert(MB_SUCCESS==result);
-      if(MB_SUCCESS != result) return result;
+      assert(moab::MB_SUCCESS==result);
+      if(moab::MB_SUCCESS != result) return result;
 
       // Check for duplicate verts. This should not happen, but could if line
       // surfaces exist. This happens when feature size is violated and skin
       // from curves on the other side of the 1D line surf gets sealed. 
       if( 1<ordered_verts.size() ) {
-        for(std::vector<MBEntityHandle>::iterator j=ordered_verts.begin()+1;
+        for(std::vector<moab::EntityHandle>::iterator j=ordered_verts.begin()+1;
 	    j!=ordered_verts.end(); ++j) {
           if( *j == *(j-1) ) {
 	    std::cout << "duplicate vertex found in curve " 
@@ -1196,7 +1196,7 @@ MBErrorCode fix_normals(MBRange surface_sets, MBTag id_tag, MBTag normal_tag, co
           ordered_verts.front()==ordered_verts.back() ) {
 	std::cout << "warning: curve " << gen::geom_id_by_handle(*i) 
                   << " is one degenerate edge" << std::endl;
-        //return MB_FAILURE; **** when this is uncommented, problems occur
+        //return moab::MB_FAILURE; **** when this is uncommented, problems occur
       }
 
       // Determine if the curve is a loop or point curve. At least 4 verts are
@@ -1205,10 +1205,10 @@ MBErrorCode fix_normals(MBRange surface_sets, MBTag id_tag, MBTag normal_tag, co
                        3<ordered_verts.size() );
 
       // get geometric endpoint sets of the curve (may be stale)
-      MBRange endpt_sets;
+      moab::Range endpt_sets;
       result = MBI()->get_child_meshsets( *i, endpt_sets );
-      assert(MB_SUCCESS==result);
-      if(MB_SUCCESS != result) return result;
+      assert(moab::MB_SUCCESS==result);
+      if(moab::MB_SUCCESS != result) return result;
 
       // do the correct number of endpt sets exist?
       const unsigned int n_endpts = (is_loop) ? 1 : 2;
@@ -1219,16 +1219,16 @@ MBErrorCode fix_normals(MBRange surface_sets, MBTag id_tag, MBTag normal_tag, co
       }
 
       // do they match the current endpoints?
-      for(MBRange::iterator j=endpt_sets.begin(); j!=endpt_sets.end(); ++j) {
-        MBRange endpt_vert;
+      for(moab::Range::iterator j=endpt_sets.begin(); j!=endpt_sets.end(); ++j) {
+        moab::Range endpt_vert;
         result = MBI()->get_entities_by_handle( *j, endpt_vert );
-        if(MB_SUCCESS != result) return result;
-        assert(MB_SUCCESS==result);
+        if(moab::MB_SUCCESS != result) return result;
+        assert(moab::MB_SUCCESS==result);
         if(1 != endpt_vert.size()) {
 	  std::cout << "curve " << gen::geom_id_by_handle(*i) 
                     << " has" << endpt_vert.size() 
                     << " endpoint vertices in the geometric vertex set" << std::endl;     
-          return MB_INVALID_SIZE;
+          return moab::MB_INVALID_SIZE;
         }
         if(endpt_vert.front()!=ordered_verts.front() &&
           endpt_vert.front()!=ordered_verts.back() ) {
@@ -1238,12 +1238,12 @@ MBErrorCode fix_normals(MBRange surface_sets, MBTag id_tag, MBTag normal_tag, co
       }
 
       // create the edges of the curve
-      std::vector<MBEntityHandle> ordered_edges(ordered_verts.size()-1);
+      std::vector<moab::EntityHandle> ordered_edges(ordered_verts.size()-1);
       for(unsigned int j=0; j<ordered_verts.size()-1; ++j) {
-        MBEntityHandle edge;
-        result = MBI()->create_element( MBEDGE, &ordered_verts[j], 2, edge );
-        assert(MB_SUCCESS==result);
-        if(MB_SUCCESS != result) return result;
+        moab::EntityHandle edge;
+        result = MBI()->create_element( moab::MBEDGE, &ordered_verts[j], 2, edge );
+        assert(moab::MB_SUCCESS==result);
+        if(moab::MB_SUCCESS != result) return result;
         ordered_edges[j] = edge;
       }
 
@@ -1252,36 +1252,36 @@ MBErrorCode fix_normals(MBRange surface_sets, MBTag id_tag, MBTag normal_tag, co
 
       // clear the set
       result = MBI()->clear_meshset( &(*i), 1 );
-      assert(MB_SUCCESS==result);
-      if(MB_SUCCESS != result) return result;
+      assert(moab::MB_SUCCESS==result);
+      if(moab::MB_SUCCESS != result) return result;
 
       // add the verts then edges to the curve set
       result = MBI()->add_entities( *i, &ordered_verts[0], ordered_verts.size() );
-      assert(MB_SUCCESS==result);
-      if(MB_SUCCESS != result) return result;
+      assert(moab::MB_SUCCESS==result);
+      if(moab::MB_SUCCESS != result) return result;
       result = MBI()->add_entities( *i, &ordered_edges[0], ordered_edges.size() );
-      assert(MB_SUCCESS==result);
-      if(MB_SUCCESS != result) return result;
+      assert(moab::MB_SUCCESS==result);
+      if(moab::MB_SUCCESS != result) return result;
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[], 
-                                          const MBTag geom_tag,
-                                          const MBTag size_tag,
+moab::ErrorCode get_geom_size_before_sealing( const moab::Range geom_sets[], 
+                                          const moab::Tag geom_tag,
+                                          const moab::Tag size_tag,
                                           bool debug,
                                           bool verbose ) 
 {
-  MBErrorCode rval;
+  moab::ErrorCode rval;
   for( int dim = 1 ; dim < 4 ; ++dim ) 
     {
-    for(MBRange::iterator i=geom_sets[dim].begin() ; i != geom_sets[dim].end() ; i++) 
+    for(moab::Range::iterator i=geom_sets[dim].begin() ; i != geom_sets[dim].end() ; i++) 
       {
 	double size;
 	//std::cout << "dim = " << dim << " *i =" << *i << std::endl;
 	rval = gen::measure( *i, geom_tag, size, debug, verbose );
 	//std::cout << " here in gen mesaure" << std::endl;
-	if(gen::error(MB_SUCCESS!=rval,"could not measure")) 
+	if(gen::error(moab::MB_SUCCESS!=rval,"could not measure")) 
 	  {
 	    return rval;
 	  }
@@ -1289,7 +1289,7 @@ MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[],
 	
 	rval = MBI()->tag_set_data( size_tag, &(*i), 1, &size );
 	//std::cout << " here in set tag data" << std::endl;
-	if(gen::error(MB_SUCCESS!=rval,"could not set size tag")) 
+	if(gen::error(moab::MB_SUCCESS!=rval,"could not set size tag")) 
 	  {
 	    return rval;
 	  }
@@ -1299,12 +1299,12 @@ MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[],
   { 
   std::cout << "finished in get_geom_size_before_sealing" << std::endl;
   }
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
 
-MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[], 
-                                         const MBTag geom_tag,
-                                         const MBTag size_tag,
+moab::ErrorCode get_geom_size_after_sealing( const moab::Range geom_sets[], 
+                                         const moab::Tag geom_tag,
+                                         const moab::Tag size_tag,
                                          const double FACET_TOL,
                                          bool debug,
                                          bool verbose ) {
@@ -1318,20 +1318,20 @@ MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[],
       size_data largest_percent[3];
       size_data smallest_size[3];
 
-      MBErrorCode rval;
+      moab::ErrorCode rval;
       for(unsigned dim=1; dim<4; dim++) {
         largest_diff[dim-1].diff       = 0; 
         largest_percent[dim-1].percent = 0; 
         smallest_size[dim-1].orig_size = std::numeric_limits<int>::max(); 
-	for(MBRange::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) {
+	for(moab::Range::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) {
 	  double orig_size = 0, new_size = 0;
 	  rval = MBI()->tag_get_data( size_tag, &(*i), 1, &orig_size );
-	  if(MB_SUCCESS != rval) {
+	  if(moab::MB_SUCCESS != rval) {
 	    std::cout << "rval=" << rval << " id=" << gen::geom_id_by_handle(*i) << std::endl;
 	  }
-	  assert(MB_SUCCESS == rval);
+	  assert(moab::MB_SUCCESS == rval);
 	  rval = gen::measure( *i, geom_tag, new_size, debug, verbose );
-	  assert(MB_SUCCESS == rval);
+	  assert(moab::MB_SUCCESS == rval);
 
           // Remember the largest difference and associated percent difference
           double diff = fabs(new_size - orig_size);
@@ -1368,10 +1368,10 @@ MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[],
 
 	  // The surface cannot change more than its zipped curves.
 	  } else if(2 == dim) {
-	    MBRange curve_sets;
+	    moab::Range curve_sets;
 	    rval = MBI()->get_child_meshsets( *i, curve_sets );
 	    double total_length = 0;
-	    for(MBRange::iterator j=curve_sets.begin(); j!=curve_sets.end(); ++j) {
+	    for(moab::Range::iterator j=curve_sets.begin(); j!=curve_sets.end(); ++j) {
 	      double length;
 	      rval = MBI()->tag_get_data( size_tag, &(*j), 1, &length );
 	      total_length += length;
@@ -1379,13 +1379,13 @@ MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[],
 	    if(total_length*FACET_TOL < fabs(new_size - orig_size)) print_warning = true;
 	    // The volume cannot change more than the "cylinder" of error around each curve.
 	  } else if(3 == dim) {
-	    MBRange surf_sets;
+	    moab::Range surf_sets;
 	    rval = MBI()->get_child_meshsets( *i, surf_sets );
 	    double total_length = 0;
-	    for(MBRange::iterator j=surf_sets.begin(); j!=surf_sets.end(); ++j) {          
-	      MBRange curve_sets;
+	    for(moab::Range::iterator j=surf_sets.begin(); j!=surf_sets.end(); ++j) {          
+	      moab::Range curve_sets;
 	      rval = MBI()->get_child_meshsets( *j, curve_sets );
-	      for(MBRange::iterator k=curve_sets.begin(); k!=curve_sets.end(); ++k) {
+	      for(moab::Range::iterator k=curve_sets.begin(); k!=curve_sets.end(); ++k) {
 		double length;
 		rval = MBI()->tag_get_data( size_tag, &(*j), 1, &length );
 		total_length += length;
@@ -1395,7 +1395,7 @@ MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[],
               print_warning = true;
             }
 	  } else {
-	    return MB_FAILURE;
+	    return moab::MB_FAILURE;
 	  }
 	  if(print_warning && debug) {
 	    std::cout << "  dim=" << dim << " id=" << gen::geom_id_by_handle(*i)
@@ -1433,38 +1433,38 @@ MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[],
   	          << ", percent_change=" << smallest_size[dim-1].percent << std::endl;
       }
       std::cout.unsetf(std::ios::scientific|std::ios::showpos);
-      return MB_SUCCESS;
+      return moab::MB_SUCCESS;
 }
 
-MBErrorCode delete_merged_curves( MBRange &existing_curve_sets, MBTag merge_tag, bool debug){
+moab::ErrorCode delete_merged_curves( moab::Range &existing_curve_sets, moab::Tag merge_tag, bool debug){
 
-  MBErrorCode result; 
+  moab::ErrorCode result; 
 
-   MBRange curves_to_delete;
-    result = MBI()->get_entities_by_type_and_tag(0, MBENTITYSET, &merge_tag, NULL,
+   moab::Range curves_to_delete;
+    result = MBI()->get_entities_by_type_and_tag(0, moab::MBENTITYSET, &merge_tag, NULL,
                                                  1, curves_to_delete);
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     // loop over the curves to delete 
-    for(MBRange::const_iterator i=curves_to_delete.begin(); i!=curves_to_delete.end(); ++i) {
+    for(moab::Range::const_iterator i=curves_to_delete.begin(); i!=curves_to_delete.end(); ++i) {
       // get the curve_to_keep
-      MBEntityHandle curve_to_keep;
+      moab::EntityHandle curve_to_keep;
       result = MBI()->tag_get_data( merge_tag, &(*i), 1, &curve_to_keep );
-      if(MB_SUCCESS != result) return result;
+      if(moab::MB_SUCCESS != result) return result;
       // get parent surface of the curve_to_delete
-      MBRange parent_surfs;
+      moab::Range parent_surfs;
       result = MBI()->get_parent_meshsets( *i, parent_surfs );
-      if(MB_SUCCESS != result) return result;
+      if(moab::MB_SUCCESS != result) return result;
       // remove the curve_to_delete and replace with curve_to_keep
-      for(MBRange::iterator j=parent_surfs.begin(); j!=parent_surfs.end(); ++j) {
+      for(moab::Range::iterator j=parent_surfs.begin(); j!=parent_surfs.end(); ++j) {
         result = MBI()->remove_parent_child( *j, *i );
-        if(MB_SUCCESS != result) return result;
+        if(moab::MB_SUCCESS != result) return result;
         result = MBI()->add_parent_child( *j, curve_to_keep );
-        if(MB_SUCCESS != result) return result;
+        if(moab::MB_SUCCESS != result) return result;
       }
     }
     result = MBI()->delete_entities( curves_to_delete );
-    assert(MB_SUCCESS == result);
-    if ( result != MB_SUCCESS ) 
+    assert(moab::MB_SUCCESS == result);
+    if ( result != moab::MB_SUCCESS ) 
       {
 	std::cout << "Houston, we have a problem" << std::endl;
       }
@@ -1476,45 +1476,45 @@ MBErrorCode delete_merged_curves( MBRange &existing_curve_sets, MBTag merge_tag,
 
 }
 
-MBErrorCode delete_sealing_tags( MBTag normal_tag, MBTag merge_tag, MBTag size_tag, MBTag orig_curve_tag){
+moab::ErrorCode delete_sealing_tags( moab::Tag normal_tag, moab::Tag merge_tag, moab::Tag size_tag, moab::Tag orig_curve_tag){
 
-  MBErrorCode result; 
+  moab::ErrorCode result; 
 
   result = MBI()->tag_delete( normal_tag );
-    if(MB_SUCCESS != result) return result;
+    if(moab::MB_SUCCESS != result) return result;
     result = MBI()->tag_delete( merge_tag );
-    if(MB_SUCCESS != result) return result;
+    if(moab::MB_SUCCESS != result) return result;
     result = MBI()->tag_delete( size_tag );
-    if(MB_SUCCESS != result) return result;
+    if(moab::MB_SUCCESS != result) return result;
     result = MBI()->tag_delete( orig_curve_tag );
-    if(MB_SUCCESS != result) return result;
+    if(moab::MB_SUCCESS != result) return result;
 
   return result; 
 }
 
-MBErrorCode get_unmerged_curves( MBEntityHandle surface, std::vector<MBEntityHandle> &curves, 
-                                 std::vector<MBEntityHandle> &unmerged_curves, 
-                                 MBTag merge_tag, 
+moab::ErrorCode get_unmerged_curves( moab::EntityHandle surface, std::vector<moab::EntityHandle> &curves, 
+                                 std::vector<moab::EntityHandle> &unmerged_curves, 
+                                 moab::Tag merge_tag, 
                                  bool verbose, 
                                  bool debug) {
 
-  MBErrorCode result; 
+  moab::ErrorCode result; 
 
    result = MBI()->get_child_meshsets( surface, curves );
-      if(gen::error(MB_SUCCESS!=result,"could not get child sets")) return result;
-      assert(MB_SUCCESS==result);
+      if(gen::error(moab::MB_SUCCESS!=result,"could not get child sets")) return result;
+      assert(moab::MB_SUCCESS==result);
 
       // Update the curve_sets with that contain entity_to_delete curves with their
       // entity_to_keep curves. Unmerged_curve_sets will end up holding the curves
       // of this surface that are not merged with another curve in this surface.
-      for(std::vector<MBEntityHandle>::iterator j=curves.begin();
+      for(std::vector<moab::EntityHandle>::iterator j=curves.begin();
 	  j!=curves.end(); j++) {
-        MBEntityHandle merged_curve, curve;
+        moab::EntityHandle merged_curve, curve;
         result = MBI()->tag_get_data( merge_tag, &(*j), 1, &merged_curve );
-        assert(MB_TAG_NOT_FOUND==result || MB_SUCCESS==result);     
-        if(MB_TAG_NOT_FOUND == result) {
+        assert(moab::MB_TAG_NOT_FOUND==result || moab::MB_SUCCESS==result);     
+        if(moab::MB_TAG_NOT_FOUND == result) {
           curve = *j;
-        } else if(MB_SUCCESS == result) {
+        } else if(moab::MB_SUCCESS == result) {
 	  if(debug) {
             std::cout << "  curve_id=" << gen::geom_id_by_handle(*j) 
                       << " is entity_to_delete" << std::endl;
@@ -1528,7 +1528,7 @@ MBErrorCode get_unmerged_curves( MBEntityHandle surface, std::vector<MBEntityHan
       
 	// Add a curve (whether it is merged or not) if it is not in unmerged_merged_curve_sets. 
         // If it is merged, then the curve handle will appear later and we will remove it. 
-	std::vector<MBEntityHandle>::iterator k=find(unmerged_curves.begin(), 
+	std::vector<moab::EntityHandle>::iterator k=find(unmerged_curves.begin(), 
 	  unmerged_curves.end(), curve);
         if(unmerged_curves.end() == k) {
 
@@ -1542,25 +1542,25 @@ MBErrorCode get_unmerged_curves( MBEntityHandle surface, std::vector<MBEntityHan
       }
 
 
-  return MB_SUCCESS; 
+  return moab::MB_SUCCESS; 
 
 }
 
 
-MBErrorCode create_skin_vert_loops( MBRange &skin_edges, MBRange tris, std::vector < std::vector <MBEntityHandle> > &skin , int surf_id, bool &cont, bool debug) {
+moab::ErrorCode create_skin_vert_loops( moab::Range &skin_edges, moab::Range tris, std::vector < std::vector <moab::EntityHandle> > &skin , int surf_id, bool &cont, bool debug) {
 
- MBErrorCode result; 
+ moab::ErrorCode result; 
   
      /* Remove pairs of edges that are geometrically the same but in opposite 
         order due to a faceting error ACIS. In other words, merge (a,b) and (b,a). 
         Examples are mod13surf280 and tbm_surf1605. */
       result = arc::remove_opposite_pairs_of_edges_fast( skin_edges, debug );
-      if (MB_SUCCESS != result) {                                             
+      if (moab::MB_SUCCESS != result) {                                             
 	std::cout << "  surface " << surf_id << " failed to zip: could not remove opposite edges"   
 		  << surf_id << std::endl;  
         result = MBI()->delete_entities(skin_edges);
-        if(gen::error(MB_SUCCESS!=result,"could not delete skin edges")) return result;
-        assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not delete skin edges")) return result;
+        assert(moab::MB_SUCCESS == result);
         cont = true;
 	return result;
       }  
@@ -1571,28 +1571,28 @@ MBErrorCode create_skin_vert_loops( MBRange &skin_edges, MBRange tris, std::vect
       /* Order the edges so that the triangle is on their left side. Skin
 	 edges are adjacent to only one triangle. */
       bool catch_error = false;
-      for(MBRange::iterator j=skin_edges.begin(); j!=skin_edges.end(); j++) {
-	MBRange adj_tris;
+      for(moab::Range::iterator j=skin_edges.begin(); j!=skin_edges.end(); j++) {
+	moab::Range adj_tris;
 	result = MBI()->get_adjacencies( &(*j), 1, 2, false, adj_tris );
-        if(gen::error(MB_SUCCESS!=result,"could not get adj tris")) return result;
-	assert(MB_SUCCESS == result);
-	MBRange skin_tri = intersect( adj_tris, tris );
+        if(gen::error(moab::MB_SUCCESS!=result,"could not get adj tris")) return result;
+	assert(moab::MB_SUCCESS == result);
+	moab::Range skin_tri = intersect( adj_tris, tris );
         if(1 != skin_tri.size()) {
           std::cout << "skin_tri.size()=" << skin_tri.size() << std::endl;
           catch_error = true;
           break;
         }
 	result = arc::orient_edge_with_tri( *j, skin_tri.front() );
-        if(gen::error(MB_SUCCESS!=result,"could not orient_edge_with_tri")) return result;
-	assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not orient_edge_with_tri")) return result;
+	assert(moab::MB_SUCCESS == result);
       }
       // I NEED TO ADD BETTER CLEANUP AFTER THESE FAILURE CONDITIONS
       if(catch_error) {
 	std::cout << "  surface " << surf_id << " failed to zip: could not orient edge"   
                   << std::endl;  
         result = MBI()->delete_entities(skin_edges);
-        if(gen::error(MB_SUCCESS!=result,"could not delete skin edges")) return result;
-        assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not delete skin edges")) return result;
+        assert(moab::MB_SUCCESS == result);
         cont = true;
         return result;
       }
@@ -1600,23 +1600,23 @@ MBErrorCode create_skin_vert_loops( MBRange &skin_edges, MBRange tris, std::vect
 
 						      
       // Create loops with the skin edges.  
-      std::vector< std::vector<MBEntityHandle> > skin_loops_of_edges;
+      std::vector< std::vector<moab::EntityHandle> > skin_loops_of_edges;
       result = arc::create_loops_from_oriented_edges( skin_edges, skin_loops_of_edges, debug );
-      if(MB_SUCCESS != result) {
+      if(moab::MB_SUCCESS != result) {
 	std::cout << "  surface " << surf_id << " failed to zip: could not create loops" 
 		  << std::endl;
         result = MBI()->delete_entities(skin_edges);
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
 	cont = true;
         return result;
       }
       if(debug) std::cout << skin_loops_of_edges.size() << " skin loop(s)" << std::endl;
 
       // Convert the loops of skin edges to loops of skin verts.
-      std::vector< std::vector<MBEntityHandle> > skin_temp(skin_loops_of_edges.size());
+      std::vector< std::vector<moab::EntityHandle> > skin_temp(skin_loops_of_edges.size());
       for(unsigned int j=0; j<skin_loops_of_edges.size(); j++) {
         result = gen::ordered_verts_from_ordered_edges( skin_loops_of_edges[j], skin_temp[j] );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
 	// check to make sure that the loop is closed
 	assert(skin_temp[j].front() == skin_temp[j].back());
       }
@@ -1625,52 +1625,52 @@ MBErrorCode create_skin_vert_loops( MBRange &skin_edges, MBRange tris, std::vect
 
       // edges are no longer needed       
       result = MBI()->delete_entities(skin_edges);
-      if(gen::error(MB_SUCCESS!=result,"could not delete skin_edges")) return result;
-      assert(MB_SUCCESS == result);
+      if(gen::error(moab::MB_SUCCESS!=result,"could not delete skin_edges")) return result;
+      assert(moab::MB_SUCCESS == result);
 
       
 
- return MB_SUCCESS; 
+ return moab::MB_SUCCESS; 
 
 }
 
-MBErrorCode merge_skin_verts ( MBRange &skin_verts, MBRange &skin_edges, double SME_RESABS_TOL, int surf_id, bool cont, bool debug) {
+moab::ErrorCode merge_skin_verts ( moab::Range &skin_verts, moab::Range &skin_edges, double SME_RESABS_TOL, int surf_id, bool cont, bool debug) {
 
-   MBErrorCode result; 
+   moab::ErrorCode result; 
 
     result = MBI()->get_adjacencies( skin_edges, 0, false, skin_verts, 
-                                       MBInterface::UNION );
-        if(gen::error(MB_SUCCESS!=result,"could not get adj verts")) return result;
-        assert(MB_SUCCESS == result);
+                                       moab::Interface::UNION );
+        if(gen::error(moab::MB_SUCCESS!=result,"could not get adj verts")) return result;
+        assert(moab::MB_SUCCESS == result);
         result = gen::merge_vertices( skin_verts, SME_RESABS_TOL );         
-        if (MB_SUCCESS != result) {                                             
+        if (moab::MB_SUCCESS != result) {                                             
 	if(debug) std::cout << "result= " << result << std::endl;                  
 	std::cout << "  surface " << surf_id << " failed to zip: could not merge vertices"   
 		  << surf_id << std::endl;  
         result = MBI()->delete_entities(skin_edges);
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
 	cont = true;
         return result;
         }  
 
         // Merging vertices create degenerate edges.
         result = arc::remove_degenerate_edges( skin_edges, debug );
-        if(MB_SUCCESS!=result) {
+        if(moab::MB_SUCCESS!=result) {
 	std::cout << "  surface " << surf_id 
                   << " failed to zip: could not remove degenerate edges" << std::endl;
         result = MBI()->delete_entities(skin_edges);
-        if(gen::error(MB_SUCCESS!=result,"could not delete skin edges")) return result;
-        assert(MB_SUCCESS == result);
+        if(gen::error(moab::MB_SUCCESS!=result,"could not delete skin edges")) return result;
+        assert(moab::MB_SUCCESS == result);
 	cont = true;
         return result;
         }  
 
 
-   return MB_SUCCESS;
+   return moab::MB_SUCCESS;
 }
 
 
-MBErrorCode seal_surface_loops ( MBEntityHandle surf, MBEntityHandle skin_loops[] , std::vector < std::vector<MBEntityHandle> > skin, std::vector<MBEntityHandle> curves,  MBTag normal_tag, MBTag orig_curve_tag, double FACET_TOL, int surf_id, bool debug) {
+moab::ErrorCode seal_surface_loops ( moab::EntityHandle surf, moab::EntityHandle skin_loops[] , std::vector < std::vector<moab::EntityHandle> > skin, std::vector<moab::EntityHandle> curves,  moab::Tag normal_tag, moab::Tag orig_curve_tag, double FACET_TOL, int surf_id, bool debug) {
 
 
       /* Get the curves that are part of the surface. Use vectors to store all curve
@@ -1681,45 +1681,45 @@ MBErrorCode seal_surface_loops ( MBEntityHandle surf, MBEntityHandle skin_loops[
       // to do this more efficiently than a manual O(n) search through an 
       // unsorted vector.
 
-   MBErrorCode rval;
+   moab::ErrorCode rval;
       for(unsigned j=0; j<skin.size(); ++j) {
-        rval = MBI()->create_meshset( MESHSET_TRACK_OWNER|MESHSET_ORDERED, skin_loops[j] );
-        if(gen::error(MB_SUCCESS!=rval,"failed to zip: creating skin_loop_set failed"))
+        rval = MBI()->create_meshset( moab::MESHSET_TRACK_OWNER|moab::MESHSET_ORDERED, skin_loops[j] );
+        if(gen::error(moab::MB_SUCCESS!=rval,"failed to zip: creating skin_loop_set failed"))
           return rval;   
 
         rval = arc::set_meshset( skin_loops[j], skin[j] );    
-        if(gen::error(MB_SUCCESS!=rval,"failed ot zip: setting skin_loop_set failed")) 
+        if(gen::error(moab::MB_SUCCESS!=rval,"failed ot zip: setting skin_loop_set failed")) 
           return rval;      
       }
 
       // Keep zipping loops until each is either zipped or failed. This function
       // returns only after all loops are zipped or a failure occurs.
       for(unsigned j=0; j<skin.size(); ++j) {
-	std::vector<MBEntityHandle> skin_loop;
+	std::vector<moab::EntityHandle> skin_loop;
         rval = arc::get_meshset( skin_loops[j], skin_loop );    
-        if(gen::error(MB_SUCCESS!=rval,"failed to zip: setting skin_loop_set failed")) 
+        if(gen::error(moab::MB_SUCCESS!=rval,"failed to zip: setting skin_loop_set failed")) 
           return rval;      
 
         rval = seal_loop( debug, FACET_TOL, normal_tag, orig_curve_tag, surf, 
                           curves, skin_loop );
-        if(MB_SUCCESS != rval) {
+        if(moab::MB_SUCCESS != rval) {
 	  std::cout << "failed to zip: surface " << surf_id << ": failed to seal a loop" 
                     << std::endl;
         }
       }
  
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 
 }
 
 
 
-MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bool verbose) 
+moab::ErrorCode make_mesh_watertight(moab::EntityHandle input_set, double &facet_tol, bool verbose) 
   {
 
 
 
-    MBErrorCode result;
+    moab::ErrorCode result;
 
     //added to this function because they are called in make_watertight but aren't used until here
     const bool debug = false;
@@ -1728,14 +1728,14 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     bool is_acis=false;
 
    // initialize mesh tags
-    MBTag geom_tag, id_tag, normal_tag, merge_tag, faceting_tol_tag, 
+    moab::Tag geom_tag, id_tag, normal_tag, merge_tag, faceting_tol_tag, 
       geometry_resabs_tag, size_tag, orig_curve_tag;
     double sme_resabs_tol=1e-6;
     
    // retrieve mesh tags necessary for sealing the mesh
     result = gen::get_sealing_mesh_tags( facet_tol, sme_resabs_tol, geom_tag, id_tag, normal_tag, merge_tag, faceting_tol_tag, 
       geometry_resabs_tag, size_tag, orig_curve_tag); 
-    if(gen::error(MB_SUCCESS!=result, "could not get the mesh tags")) return result; 
+    if(gen::error(moab::MB_SUCCESS!=result, "could not get the mesh tags")) return result; 
 
 
     // In practice, use 2*facet_tol because we are always comparing 2 faceted
@@ -1752,15 +1752,15 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     }
 
     // get all geometry sets and set tracking ordering options appropriately
-    MBRange geom_sets[4];
+    moab::Range geom_sets[4];
     result=gen::get_geometry_meshsets( geom_sets, geom_tag, verbose);
-    if(gen::error(MB_SUCCESS!=result, "could not get the geometry meshsets")) return result;
+    if(gen::error(moab::MB_SUCCESS!=result, "could not get the geometry meshsets")) return result;
     
     // If desired, find each entity's size before sealing.
     if(check_geom_size) 
       {
 	result = get_geom_size_before_sealing( geom_sets, geom_tag, size_tag, debug, verbose );
-	if(gen::error(MB_SUCCESS!=result,"measuring geom size failed")) return result;
+	if(gen::error(moab::MB_SUCCESS!=result,"measuring geom size failed")) return result;
       }
     
 
@@ -1768,8 +1768,8 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     if (verbose) std::cout << "Getting entity count before sealing..." << std::endl;
     // Get entity count before sealing.
     int orig_n_tris;
-    result = MBI()->get_number_entities_by_type( 0, MBTRI, orig_n_tris );
-    assert(MB_SUCCESS == result);
+    result = MBI()->get_number_entities_by_type( 0, moab::MBTRI, orig_n_tris );
+    assert(moab::MB_SUCCESS == result);
 
     if(verbose)
     {
@@ -1780,14 +1780,14 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     
     if(verbose) std::cout << "Finding degenerate triangles... " << std::endl;
     result = find_degenerate_tris();
-    if(gen::error(result!=MB_SUCCESS,"could not determine if triangles were degenerate or not")) return result;
+    if(gen::error(result!=moab::MB_SUCCESS,"could not determine if triangles were degenerate or not")) return result;
       
 
     result = prepare_curves(geom_sets[1], geom_tag, id_tag, merge_tag, FACET_TOL, debug, verbose);
-    if(gen::error(result!=MB_SUCCESS,"could not prepare the curves")) return(result);
+    if(gen::error(result!=moab::MB_SUCCESS,"could not prepare the curves")) return(result);
       
     result = gen::check_for_geometry_sets(geom_tag, verbose);
-    if(gen::error(MB_SUCCESS!=result,"no geometry sets exist in the model. Please check curve faceting.")) return result; 
+    if(gen::error(moab::MB_SUCCESS!=result,"no geometry sets exist in the model. Please check curve faceting.")) return result; 
 
     
     if (verbose) 
@@ -1797,7 +1797,7 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     }
     result = prepare_surfaces(geom_sets[2], geom_tag, id_tag, normal_tag, merge_tag,
                               orig_curve_tag,SME_RESABS_TOL, FACET_TOL, debug);
-    if ( gen::error(result != MB_SUCCESS, "I have failed to zip")) return result;  
+    if ( gen::error(result != moab::MB_SUCCESS, "I have failed to zip")) return result;  
       
 
     // After zipping surfaces, merged curve entity_to_deletes are no longer needed.
@@ -1805,7 +1805,7 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     // ARE THEIR ORPHANED CHILD VERTEX SETS STILL AROUND? 
     if(verbose) std::cout << "Adjusting parent-child links then removing merged curves..." << std::endl;
     result = delete_merged_curves( geom_sets[1], merge_tag, debug);
-    if(gen::error(MB_SUCCESS!=result, "could not delete the merged curves")) return result;
+    if(gen::error(moab::MB_SUCCESS!=result, "could not delete the merged curves")) return result;
 
 
     // SHOULD COINCIDENT SURFACES ALSO BE MERGED?
@@ -1815,14 +1815,14 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     // This function is still screwed up, but 99% right.
     if (verbose) std::cout << "Fixing inverted triangles..." << std::endl;
     result = fix_normals(geom_sets[2], id_tag, normal_tag, debug, verbose);
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
 
    
     // As sanity check, did zipping drastically change the entity's size?
     if(check_geom_size && verbose) {
       std::cout << "Checking size change of zipped entities..." << std::endl;
       result = get_geom_size_after_sealing( geom_sets, geom_tag, size_tag, FACET_TOL, debug, verbose );
-      if(gen::error(MB_SUCCESS!=result,"measuring geom size failed")) return result;
+      if(gen::error(moab::MB_SUCCESS!=result,"measuring geom size failed")) return result;
     }
    
 
@@ -1832,18 +1832,18 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     // representation.
     if (verbose) std::cout << "Restoring faceted curve representation..." << std::endl;
     result = restore_moab_curve_representation( geom_sets[1] );
-    if(gen::error(MB_SUCCESS!=result,"restore_moab_curve_representation failed")) return result;    
+    if(gen::error(moab::MB_SUCCESS!=result,"restore_moab_curve_representation failed")) return result;    
     // If all of a volume's surfaces have been deleted, delete the volume.
     if (verbose) std::cout << "Removing small volumes if all surfaces have been removed..." << std::endl;
-    for(MBRange::iterator i=geom_sets[3].begin(); i!=geom_sets[3].end(); ++i) {
+    for(moab::Range::iterator i=geom_sets[3].begin(); i!=geom_sets[3].end(); ++i) {
       int n_surfs;
       result = MBI()->num_child_meshsets( *i, &n_surfs );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       if(0 == n_surfs) {
         // Remove the volume set. This also removes parent-child relationships.
 	std::cout << "  deleted volume " << gen::geom_id_by_handle(*i)  << std::endl;
         result = MBI()->delete_entities( &(*i), 1);
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         i = geom_sets[3].erase(i) - 1;
       } 
     }
@@ -1857,7 +1857,7 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     // which doesn't actually occur any more
     //if (verbose) std::cout << "Removing stale OBB trees..." << std::endl;
     //result = cleanup::remove_obb_tree();
-    //assert(MB_SUCCESS == result);
+    //assert(moab::MB_SUCCESS == result);
 
     //std::cout << "INSERT FUNCTION HERE TO REMOVE STALE VERTS, EDGES, TRIS, VERT SETS, ETC"
     //        << std::endl;
@@ -1865,21 +1865,21 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     // Resetting meshsets so that they no longer track.
     if (verbose) std::cout << "Restoring original meshset options and tags..." << std::endl;
     for(unsigned dim=0; dim<4; dim++) {
-      for(MBRange::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) {
-        result = MBI()->set_meshset_options(*i, 1==dim ? MESHSET_ORDERED : MESHSET_SET);
-        if(MB_SUCCESS != result) return result;
+      for(moab::Range::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) {
+        result = MBI()->set_meshset_options(*i, 1==dim ? moab::MESHSET_ORDERED : moab::MESHSET_SET);
+        if(moab::MB_SUCCESS != result) return result;
       }
     }    
 
     // Tags for merging curves and checking the change in geometry size were added.
     // Delete these because they are no longer needed.
     result = delete_sealing_tags( normal_tag, merge_tag, size_tag, orig_curve_tag); 
-    if(gen::error(MB_SUCCESS!=result, "could not delete sealing tags")) return result; 
+    if(gen::error(moab::MB_SUCCESS!=result, "could not delete sealing tags")) return result; 
 
     // Print new size of the file to the user
     int sealed_n_tris;
-    result = MBI()->get_number_entities_by_type( 0, MBTRI, sealed_n_tris );
-    assert(MB_SUCCESS == result);
+    result = MBI()->get_number_entities_by_type( 0, moab::MBTRI, sealed_n_tris );
+    assert(moab::MB_SUCCESS == result);
     if (verbose)
     {
     std::cout << "  output file contains " << geom_sets[3].size() << " volumes, " 
@@ -1888,7 +1888,7 @@ MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bo
     std::cout << "  triangle count changed " << (double)sealed_n_tris/orig_n_tris
               << "x (sealed/unsealed)" << std::endl;
     }
-    return MB_SUCCESS;  
+    return moab::MB_SUCCESS;  
   }
 
 }

--- a/make_watertight/mw_func.hpp
+++ b/make_watertight/mw_func.hpp
@@ -94,13 +94,15 @@ MBErrorCode restore_moab_curve_representation( const MBRange curve_sets );
 MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[], 
                                           const MBTag geom_tag,
                                           const MBTag size_tag,
-                                          bool verbose = true );
+                                          bool debug,
+                                          bool verbose);
 /// prints changes in size to the mesh after sealing
 MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[], 
                                          const MBTag geom_tag,
                                          const MBTag size_tag,
                                          const double FACET_TOL,
-                                         bool verbose = true );
+                                         bool debug,
+                                         bool verbose );
 
 /// deletes all curves with a merge_tag and removes them from the curve sets of the mesh
 MBErrorCode delete_merged_curves(MBRange &existing_curve_sets, MBTag merge_tag, bool debug = false);

--- a/make_watertight/mw_func.hpp
+++ b/make_watertight/mw_func.hpp
@@ -113,7 +113,8 @@ MBErrorCode get_unmerged_curves( MBEntityHandle surface,
                                  std::vector<MBEntityHandle> &curves, 
                                  std::vector<MBEntityHandle> &unmerged_curves, 
                                  MBTag merge_tag, 
-                                 bool verbose);
+                                 bool verbose,
+                                 bool debug);
 
 /// takes the skin_edges from the moab skinner and creates loops of vertices between the facets and geometric curves.
 /// The vertex loops are returned in the vector array, skin. 

--- a/make_watertight/mw_func.hpp
+++ b/make_watertight/mw_func.hpp
@@ -21,124 +21,124 @@
 
 
 
-MBInterface *MOAB();
+moab::Interface *MOAB();
 
 namespace mw_func {
 
-void moab_printer(MBErrorCode error_code);
+void moab_printer(moab::ErrorCode error_code);
 
-MBErrorCode delete_all_edges();
+moab::ErrorCode delete_all_edges();
 
 /// gets all triangles from the mesh set and checks them for degeneracy.
 /// if any degenerate triangles are found, the program will exit
-MBErrorCode find_degenerate_tris();
+moab::ErrorCode find_degenerate_tris();
 
 /// prepares all curves for the make_watertight algorithm. Merges curves that are 
 /// coincident and deletes curves that are smallerthan the faceting tolerance
-MBErrorCode prepare_curves(MBRange &curve_sets, 
-                           MBTag geom_tag, 
-                           MBTag id_tag, 
-                           MBTag merge_tag, 
+moab::ErrorCode prepare_curves(moab::Range &curve_sets, 
+                           moab::Tag geom_tag, 
+                           moab::Tag id_tag, 
+                           moab::Tag merge_tag, 
                            const double FACET_TOL, 
                            const bool debug,
                            bool verbose = true );
 
-MBErrorCode create_arc_pair(  const double FACET_TOL,
-                              const MBEntityHandle surf_set,
-			      std::vector<MBEntityHandle> &skin_loop,
-			      std::vector<MBEntityHandle> &curve_sets,
-			      const MBEntityHandle front_endpt,
+moab::ErrorCode create_arc_pair(  const double FACET_TOL,
+                              const moab::EntityHandle surf_set,
+			      std::vector<moab::EntityHandle> &skin_loop,
+			      std::vector<moab::EntityHandle> &curve_sets,
+			      const moab::EntityHandle front_endpt,
                               const bool debug,
-			      MBEntityHandle &curve_set,
+			      moab::EntityHandle &curve_set,
 			      bool &curve_is_reversed,
-			      std::vector<MBEntityHandle> &curve,
-			      std::vector<MBEntityHandle> &skin_arc );
+			      std::vector<moab::EntityHandle> &curve,
+			      std::vector<moab::EntityHandle> &skin_arc );
 
-MBErrorCode seal_arc_pair( const bool debug,
+moab::ErrorCode seal_arc_pair( const bool debug,
                            const double FACET_TOL,
-                           const MBTag normal_tag,
-                           std::vector<MBEntityHandle> &edge, /* in */
-                           std::vector<MBEntityHandle> &skin /* in/out */,
+                           const moab::Tag normal_tag,
+                           std::vector<moab::EntityHandle> &edge, /* in */
+                           std::vector<moab::EntityHandle> &skin /* in/out */,
                            const int surf_id );
 
-MBErrorCode seal_loop( bool debug,
+moab::ErrorCode seal_loop( bool debug,
                        const double FACET_TOL,
-                       const MBTag normal_tag,
-                       const MBTag orig_curve_tag,
-                       const MBEntityHandle surf_set,
-                       std::vector<MBEntityHandle> &curve_sets,
-                       std::vector<MBEntityHandle> &skin_loop,
+                       const moab::Tag normal_tag,
+                       const moab::Tag orig_curve_tag,
+                       const moab::EntityHandle surf_set,
+                       std::vector<moab::EntityHandle> &curve_sets,
+                       std::vector<moab::EntityHandle> &skin_loop,
                        bool verbose = false );
 
-MBErrorCode prepare_surfaces(MBRange &surface_sets,
-                             MBTag geom_tag, 
-                             MBTag id_tag, 
-                             MBTag normal_tag, 
-                             MBTag merge_tag,
-                             MBTag orig_curve_tag,
+moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
+                             moab::Tag geom_tag, 
+                             moab::Tag id_tag, 
+                             moab::Tag normal_tag, 
+                             moab::Tag merge_tag,
+                             moab::Tag orig_curve_tag,
                              const double SME_RESABS_TOL,
                              const double FACET_TOL, 
                              const bool debug,
                              bool verbose = true);
 
 /// re-orients triangles with inverted normal vectors after being sealed
-MBErrorCode fix_normals(MBRange surface_sets, 
-                        MBTag id_tag, 
-                        MBTag normal_tag,
+moab::ErrorCode fix_normals(moab::Range surface_sets, 
+                        moab::Tag id_tag, 
+                        moab::Tag normal_tag,
                         const bool debug,
                         const bool verbose);
 
-MBErrorCode restore_moab_curve_representation( const MBRange curve_sets );
+moab::ErrorCode restore_moab_curve_representation( const moab::Range curve_sets );
 
 /// prints the size of every entity in geom_sets
-MBErrorCode get_geom_size_before_sealing( const MBRange geom_sets[], 
-                                          const MBTag geom_tag,
-                                          const MBTag size_tag,
+moab::ErrorCode get_geom_size_before_sealing( const moab::Range geom_sets[], 
+                                          const moab::Tag geom_tag,
+                                          const moab::Tag size_tag,
                                           bool debug,
                                           bool verbose);
 /// prints changes in size to the mesh after sealing
-MBErrorCode get_geom_size_after_sealing( const MBRange geom_sets[], 
-                                         const MBTag geom_tag,
-                                         const MBTag size_tag,
+moab::ErrorCode get_geom_size_after_sealing( const moab::Range geom_sets[], 
+                                         const moab::Tag geom_tag,
+                                         const moab::Tag size_tag,
                                          const double FACET_TOL,
                                          bool debug,
                                          bool verbose );
 
 /// deletes all curves with a merge_tag and removes them from the curve sets of the mesh
-MBErrorCode delete_merged_curves(MBRange &existing_curve_sets, MBTag merge_tag, bool debug = false);
+moab::ErrorCode delete_merged_curves(moab::Range &existing_curve_sets, moab::Tag merge_tag, bool debug = false);
 
 /// deletes all tags created for use in sealing the model
-MBErrorCode delete_sealing_tags( MBTag normal_tag, MBTag merge_tag, MBTag size_tag, MBTag orig_curve_tag);
+moab::ErrorCode delete_sealing_tags( moab::Tag normal_tag, moab::Tag merge_tag, moab::Tag size_tag, moab::Tag orig_curve_tag);
 
 /// gets all curve sets an returns them in curves. Places any unmerged curves in unmerged_curves. 
-MBErrorCode get_unmerged_curves( MBEntityHandle surface, 
-                                 std::vector<MBEntityHandle> &curves, 
-                                 std::vector<MBEntityHandle> &unmerged_curves, 
-                                 MBTag merge_tag, 
+moab::ErrorCode get_unmerged_curves( moab::EntityHandle surface, 
+                                 std::vector<moab::EntityHandle> &curves, 
+                                 std::vector<moab::EntityHandle> &unmerged_curves, 
+                                 moab::Tag merge_tag, 
                                  bool verbose,
                                  bool debug);
 
 /// takes the skin_edges from the moab skinner and creates loops of vertices between the facets and geometric curves.
 /// The vertex loops are returned in the vector array, skin. 
-MBErrorCode create_skin_vert_loops( MBRange &skin_edges, MBRange tris, std::vector < std::vector <MBEntityHandle> > &skin, int surf_id, bool &cont, bool debug);
+moab::ErrorCode create_skin_vert_loops( moab::Range &skin_edges, moab::Range tris, std::vector < std::vector <moab::EntityHandle> > &skin, int surf_id, bool &cont, bool debug);
 
 /// merges any skin vertices closer in proximity than the SME_RESABS_TOL.
 /// It then checks the skins for any degenerate edges resultant of vertex merging.
-MBErrorCode merge_skin_verts ( MBRange &skin_verts, MBRange &skin_edges, double SME_RESABS_TOL, int surf_id, bool cont, bool debug);
+moab::ErrorCode merge_skin_verts ( moab::Range &skin_verts, moab::Range &skin_edges, double SME_RESABS_TOL, int surf_id, bool cont, bool debug);
 
 /// runs the make_watertight algorithm on each set of skin_loops for the surface, surf.
-MBErrorCode seal_surface_loops ( MBEntityHandle surf,
-                                 MBEntityHandle skin_loops[], 
-                                 std::vector < std::vector<MBEntityHandle> > skin, 
-                                 std::vector<MBEntityHandle> curves, 
-                                 MBTag normal_tag, 
-                                 MBTag orig_curve_tag, 
+moab::ErrorCode seal_surface_loops ( moab::EntityHandle surf,
+                                 moab::EntityHandle skin_loops[], 
+                                 std::vector < std::vector<moab::EntityHandle> > skin, 
+                                 std::vector<moab::EntityHandle> curves, 
+                                 moab::Tag normal_tag, 
+                                 moab::Tag orig_curve_tag, 
                                  double FACET_TOL, 
                                  int surf_id, 
                                  bool debug);
 
 /// takes the mesh in input_set and makes it watertight
-MBErrorCode make_mesh_watertight(MBEntityHandle input_set, double &facet_tol, bool verbose = true);
+moab::ErrorCode make_mesh_watertight(moab::EntityHandle input_set, double &facet_tol, bool verbose = true);
 
 
 

--- a/make_watertight/post_process.cpp
+++ b/make_watertight/post_process.cpp
@@ -26,10 +26,10 @@
 #include <cmath>
 #include <ctime>
 #include <vector>
-#include "MBCore.hpp"
+#include "moab/Core.hpp"
 #include "MBTagConventions.hpp"
-#include "MBRange.hpp"
-#include "MBSkinner.hpp"
+#include "moab/Range.hpp"
+#include "moab/Skinner.hpp"
 
 #include "gen.hpp"
 #include "arc.hpp"
@@ -39,39 +39,39 @@
 
 
 
-MBInterface *MBI();
+moab::Interface *MBI();
 
-MBErrorCode delete_all_edges() {
+moab::ErrorCode delete_all_edges() {
   // delete all of the edges. Never keep edges. They are too hard to track and use
   // due to orientation and multiple entities errors when merging.
-  MBErrorCode result;
-  MBRange edges;
-  result = MBI()->get_entities_by_type( 0, MBEDGE, edges );
-  assert(MB_SUCCESS == result);
+  moab::ErrorCode result;
+  moab::Range edges;
+  result = MBI()->get_entities_by_type( 0, moab::MBEDGE, edges );
+  assert(moab::MB_SUCCESS == result);
   result = MBI()->delete_entities( edges );
-  assert(MB_SUCCESS == result);
-  return MB_SUCCESS;
+  assert(moab::MB_SUCCESS == result);
+  return moab::MB_SUCCESS;
 }
 
 // Input: unordered sets of curves that do not track ownership
 // Output: ordered sets of verts that do track ownership. All edges are deleted.
-MBErrorCode prepare_curves(MBRange &curve_sets, 
-                           MBTag geom_tag, MBTag id_tag, MBTag merge_tag,
+moab::ErrorCode prepare_curves(moab::Range &curve_sets, 
+                           moab::Tag geom_tag, moab::Tag id_tag, moab::Tag merge_tag,
                            double const MERGE_TOL, double const FACET_TOL) {
-  MBErrorCode result;
+  moab::ErrorCode result;
 
   // process each curve
-  for(MBRange::iterator i=curve_sets.begin(); i!=curve_sets.end(); i++ ) {
+  for(moab::Range::iterator i=curve_sets.begin(); i!=curve_sets.end(); i++ ) {
     // get the curve id of the curve meshset
     int id;
     result = MBI()->tag_get_data( id_tag, &(*i), 1, &id );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     std::cout << "curve " << id << std::endl;
 
     // get the range of edges of the curve meshset
-    std::vector<MBEntityHandle> curve_edges;
-    result = MBI()->get_entities_by_type( *i, MBEDGE, curve_edges );
-    assert( MB_SUCCESS == result );
+    std::vector<moab::EntityHandle> curve_edges;
+    result = MBI()->get_entities_by_type( *i, moab::MBEDGE, curve_edges );
+    assert( moab::MB_SUCCESS == result );
 
     /* Merge the endpoints of the curve and remove its edges if it is too small.
     Use the MERGE_TOL because these edges will be merged with the MERGE_TOL 
@@ -82,39 +82,39 @@ MBErrorCode prepare_curves(MBRange &curve_sets,
                 << " n_verts=" << curve_edges.size()+1 << std::endl;
 
       // get the endpoints of the curve
-      MBRange endpt_sets;
+      moab::Range endpt_sets;
       result = MBI()->get_child_meshsets( *i, endpt_sets );
-      assert(MB_SUCCESS==result);
+      assert(moab::MB_SUCCESS==result);
       std::cout << "  endpt_sets.size()=" << endpt_sets.size() << std::endl;
       if(endpt_sets.empty()) {
         assert(false);
       } else if(1 == endpt_sets.size()) {
         // nothing
       } else if(2 == endpt_sets.size()) {
-        MBRange front_endpt, back_endpt;
-        result = MBI()->get_entities_by_type( endpt_sets.front(), MBVERTEX, front_endpt);
-        assert(MB_SUCCESS == result);
+        moab::Range front_endpt, back_endpt;
+        result = MBI()->get_entities_by_type( endpt_sets.front(), moab::MBVERTEX, front_endpt);
+        assert(moab::MB_SUCCESS == result);
         assert(1 == front_endpt.size());
-        result = MBI()->get_entities_by_type( endpt_sets.back(), MBVERTEX, back_endpt);
-        assert(MB_SUCCESS == result);
+        result = MBI()->get_entities_by_type( endpt_sets.back(), moab::MBVERTEX, back_endpt);
+        assert(moab::MB_SUCCESS == result);
         assert(1 == back_endpt.size());
         // merge the endpoints-ALWAYS CHECK TO AVOID MERGING THE SAME ENTITY!!!
         if(front_endpt[0] != back_endpt[0]) {
           result = MBI()->merge_entities( front_endpt[0], back_endpt[0], false, true);
-          assert(MB_SUCCESS == result);
+          assert(moab::MB_SUCCESS == result);
           // check for and remove degenerate edges caused by the merge
-          MBRange edges;
-          MBEntityHandle temp = front_endpt[0];
+          moab::Range edges;
+          moab::EntityHandle temp = front_endpt[0];
           result = MBI()->get_adjacencies( &temp, 1, 1, false, edges);
-          assert(MB_SUCCESS == result);
-          for(MBRange::iterator j=edges.begin(); j!=edges.end(); j++) {
-            const MBEntityHandle *conn;
+          assert(moab::MB_SUCCESS == result);
+          for(moab::Range::iterator j=edges.begin(); j!=edges.end(); j++) {
+            const moab::EntityHandle *conn;
             int n_verts;
             result = MBI()->get_connectivity( *j, conn, n_verts); 
-            assert(MB_SUCCESS == result);
+            assert(moab::MB_SUCCESS == result);
             if(conn[0] == conn[1]) {
               result = MBI()->delete_entities( &(*j), 1 );
-              assert(MB_SUCCESS == result);
+              assert(moab::MB_SUCCESS == result);
             }
           }
 	}
@@ -126,35 +126,35 @@ MBErrorCode prepare_curves(MBRange &curve_sets,
       
       // Remove the curve set. This also removes parent-child relationships.
       result = MBI()->delete_entities( &(*i), 1);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       i = curve_sets.erase(i) - 1;
       continue;
     }
 
     // convert the curve of edges into a curve of verts 
-    std::vector<MBEntityHandle> ordered_verts;
+    std::vector<moab::EntityHandle> ordered_verts;
     result = gen::ordered_verts_from_ordered_edges( curve_edges, ordered_verts);
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
 
     // the edges are no longer needed
     result = MBI()->delete_entities( &curve_edges[0], curve_edges.size() );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
 
     // replace the unordered edges with the ordered verts
     result = arc::set_meshset( *i, ordered_verts );
-    assert(MB_SUCCESS == result);      
+    assert(moab::MB_SUCCESS == result);      
   }
 
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
 
 /* Isolate the failure by removing the curve and loop that failed. The zip_loop
    function will be called again on the remaining loops and curves. */
-MBErrorCode remove_failed_loop_and_curve( std::vector<std::vector<MBEntityHandle> > &skin,
-                                          std::vector<std::vector<MBEntityHandle> > &curves,
+moab::ErrorCode remove_failed_loop_and_curve( std::vector<std::vector<moab::EntityHandle> > &skin,
+                                          std::vector<std::vector<moab::EntityHandle> > &curves,
                                           std::vector<int> &curve_ids,
-                                          std::vector<MBEntityHandle> &curve_sets,
-                                          //MBRange &curve_sets,
+                                          std::vector<moab::EntityHandle> &curve_sets,
+                                          //moab::Range &curve_sets,
 					  const unsigned int loop,
                                           const unsigned int curve ) {
   skin.erase( skin.begin()+loop );
@@ -162,48 +162,48 @@ MBErrorCode remove_failed_loop_and_curve( std::vector<std::vector<MBEntityHandle
   curve_ids.erase( curve_ids.begin()+curve ); 
   curve_sets.erase( curve_sets.begin()+curve );
   std::cout << "remove_failed_loop: removed loop " << loop << std::endl;
-  return MB_SUCCESS;
+  return moab::MB_SUCCESS;
 }
 
   // input: surface sets, ordered curve sets,
   // output: skin arcs corresponding to curves are added to parent surface sets
-MBErrorCode prepare_surfaces(MBRange &surface_sets,
-                             MBTag geom_tag, MBTag id_tag, MBTag normal_tag, MBTag merge_tag,
+moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
+                             moab::Tag geom_tag, moab::Tag id_tag, moab::Tag normal_tag, moab::Tag merge_tag,
                              const double SME_RESABS_TOL, const double FACET_TOL, 
                                const double MERGE_TOL) {
     
-    MBErrorCode result;
+    moab::ErrorCode result;
 
     // loop over each surface meshset
-    for(MBRange::iterator i=surface_sets.begin(); i!=surface_sets.end(); i++ ) {
+    for(moab::Range::iterator i=surface_sets.begin(); i!=surface_sets.end(); i++ ) {
 
       // get the surf id of the surface meshset
       int surf_id;
       result = MBI()->tag_get_data( id_tag, &(*i), 1, &surf_id );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       std::cout << "  surf id=" << surf_id << std::endl;
 
       // get facets of the surface meshset
-      MBRange tris;
-      result = MBI()->get_entities_by_type( *i, MBTRI, tris );
-      assert(MB_SUCCESS == result);
+      moab::Range tris;
+      result = MBI()->get_entities_by_type( *i, moab::MBTRI, tris );
+      assert(moab::MB_SUCCESS == result);
 
       // Get the curves sets
-      std::vector<MBEntityHandle> curve_sets, unmerged_curve_sets;
+      std::vector<moab::EntityHandle> curve_sets, unmerged_curve_sets;
       result = MBI()->get_child_meshsets( *i, curve_sets );
-      assert(MB_SUCCESS==result);
+      assert(moab::MB_SUCCESS==result);
 
       // Update the curve_sets with that contain entity_to_delete curves with their
       // entity_to_keep curves. Unmerged_curve_sets will end up holding the curves
       // of this surface that are not merged with another curve in this surface.
-      for(std::vector<MBEntityHandle>::iterator j=curve_sets.begin();
+      for(std::vector<moab::EntityHandle>::iterator j=curve_sets.begin();
 	  j!=curve_sets.end(); j++) {
-        MBEntityHandle merged_curve, curve;
+        moab::EntityHandle merged_curve, curve;
         result = MBI()->tag_get_data( merge_tag, &(*j), 1, &merged_curve );
-        assert(MB_TAG_NOT_FOUND==result || MB_SUCCESS==result);     
-        if(MB_TAG_NOT_FOUND==result) {
+        assert(moab::MB_TAG_NOT_FOUND==result || moab::MB_SUCCESS==result);     
+        if(moab::MB_TAG_NOT_FOUND==result) {
           curve = *j;
-        } else if(MB_SUCCESS == result) {
+        } else if(moab::MB_SUCCESS == result) {
 	  std::cout << "  curve " << gen::geom_id_by_handle(*j) 
                     << " is entity_to_delete" << std::endl;
           curve = merged_curve;
@@ -214,7 +214,7 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
         }
       
         // If the curve is in unmerged_curve_sets, then remove it. Otherwise add it.
-	std::vector<MBEntityHandle>::iterator k=find(unmerged_curve_sets.begin(), 
+	std::vector<moab::EntityHandle>::iterator k=find(unmerged_curve_sets.begin(), 
 	  unmerged_curve_sets.end(), curve);
         if(unmerged_curve_sets.end() == k) {
   	  //std::cout << "  curve " << gen::geom_id_by_handle(*k) 
@@ -228,13 +228,13 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
       // If all of the curves are merged, remove the surfaces facets.
       if(unmerged_curve_sets.empty()) {
         result = MBI()->remove_entities( *i, tris);                                           
-	assert(MB_SUCCESS == result);                                                         
+	assert(moab::MB_SUCCESS == result);                                                         
 	std::cout << "  removed " << tris.size() << " facets and deleted surface" << std::endl;
 	result = MBI()->delete_entities( tris );                                              
-	assert(MB_SUCCESS == result);
+	assert(moab::MB_SUCCESS == result);
         // remove the surface set itself
         result = MBI()->delete_entities( &(*i), 1);
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
         i = surface_sets.erase(i) - 1;
         continue;
       }
@@ -245,22 +245,22 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
       // Save the normals of the facets. These will later be used to determine if
       // the tri became inverted.
       result = gen::save_normals( tris, normal_tag );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
   
       // get the range of skin edges from the range of facets
-      MBSkinner tool(MBI());
-      MBRange skin_edges;
+      moab::Skinner tool(MBI());
+      moab::Range skin_edges;
 
       // merge the vertices of the skin
       // BRANDON: For some reason cgm2moab does not do this? This was the 
       // problem with mod13 surf 881. Two skin verts were coincident. A tol=1e-10
       // found the verts, but tol=0 did not.
-      MBRange skin_verts;
+      moab::Range skin_verts;
       result = MBI()->get_adjacencies( skin_edges, 0, false, skin_verts, 
-                                       MBInterface::UNION );
-      assert(MB_SUCCESS == result);
+                                       moab::Interface::UNION );
+      assert(moab::MB_SUCCESS == result);
       result = gen::merge_vertices( skin_verts, SME_RESABS_TOL );         
-      if (MB_SUCCESS != result) {                                             
+      if (moab::MB_SUCCESS != result) {                                             
 	std::cout << "result= " << result << std::endl;                  
 	std::cout << "SURFACE_ZIPPING_FAILURE: could not merge vertices, surf_id="   
 		  << surf_id << std::endl;  
@@ -268,8 +268,8 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
       }  
 						      
       // Create loops with the skin edges.  
-      std::vector< std::vector<MBEntityHandle> > skin_loops_of_edges;
-      if(MB_SUCCESS != result) {
+      std::vector< std::vector<moab::EntityHandle> > skin_loops_of_edges;
+      if(moab::MB_SUCCESS != result) {
 	std::cout << "SURFACE_ZIPPING_FAILURE: could not create loops for surf_id=" 
 		  << surf_id << std::endl;
 	continue;
@@ -278,50 +278,50 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
                 << " skin loop(s)." << std::endl;
     
       // Convert the loops of skin edges to loops of skin verts.
-      std::vector< std::vector<MBEntityHandle> > skin(skin_loops_of_edges.size());
+      std::vector< std::vector<moab::EntityHandle> > skin(skin_loops_of_edges.size());
       for(unsigned int j=0; j<skin_loops_of_edges.size(); j++) {
         result = gen::ordered_verts_from_ordered_edges( skin_loops_of_edges[j], skin[j] );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
 	// check to make sure that the loop is closed
 	assert(skin[j].front() == skin[j].back());
       }
 
       // edges are no longer needed       
       result = delete_all_edges();
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
 
       /* Get the curves that are part of the surface. Use vectors to store all curve
 	 stuff so that we can remove curves from the set as they are zipped. */
       //curve_sets.clear();
 
       //result = MBI()->get_child_meshsets( *i, curve_sets );
-      //assert(MB_SUCCESS==result);
+      //assert(moab::MB_SUCCESS==result);
       std::vector<int> curve_ids;
       int curve_id;
-      std::vector<std::vector<MBEntityHandle> > curves;
-      //for(MBRange::iterator j=curve_sets.begin(); j!=curve_sets.end(); j++) {
+      std::vector<std::vector<moab::EntityHandle> > curves;
+      //for(moab::Range::iterator j=curve_sets.begin(); j!=curve_sets.end(); j++) {
       //for(unsigned int j=0; j<curve_sets.size(); j++) {
-      for(std::vector<MBEntityHandle>::iterator j=curve_sets.begin(); 
+      for(std::vector<moab::EntityHandle>::iterator j=curve_sets.begin(); 
         j!=curve_sets.end(); j++) {
 
         // If a delete_curve, replace it with the keep_curve. This approach allows
         // for duplicates because we are using vectors instead of ranges. Note that
         // parent-child links also cannot store duplicate handles.
-        MBEntityHandle merged_curve;
-	//MBEntityHandle temp = curve_sets[j];
+        moab::EntityHandle merged_curve;
+	//moab::EntityHandle temp = curve_sets[j];
         result = MBI()->tag_get_data( merge_tag, &(*j), 1, &merged_curve );     
-        assert(MB_TAG_NOT_FOUND==result || MB_SUCCESS==result);
-        if(MB_SUCCESS == result) *j = merged_curve;
+        assert(moab::MB_TAG_NOT_FOUND==result || moab::MB_SUCCESS==result);
+        if(moab::MB_SUCCESS == result) *j = merged_curve;
 
 	// do not add a curve if it contains nothing
 	//temp = curve_sets[j];
 	result = MBI()->tag_get_data( id_tag, &(*j), 1, &curve_id );
-	assert(MB_SUCCESS == result);
+	assert(moab::MB_SUCCESS == result);
 	std::cout << "  curve_id=" << curve_id << " handle=" << *j << std::endl;
 	curve_ids.push_back(curve_id);
-	std::vector<MBEntityHandle> curve;
+	std::vector<moab::EntityHandle> curve;
 	result = arc::get_meshset( *j, curve );
-	assert(MB_SUCCESS == result);
+	assert(moab::MB_SUCCESS == result);
 	curves.push_back( curve );
       }
 
@@ -330,24 +330,24 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
       while(!skin.empty()) {
         //result = zip_loop( normal_tag, FACET_TOL, MERGE_TOL, 
 	//                 curves, skin, curve_ids, *i, curve_sets );
-        if(MB_SUCCESS != result) {
+        if(moab::MB_SUCCESS != result) {
 	  std::cout << "SURFACE_ZIPPING_FAILURE: could not zip surf_id=" << surf_id << std::endl;
         }
       }
 
       // mod13surf2996, 3028 and 2997 are adjacent to the same bad geometry (figure 8 loop)
-      //assert(MB_SUCCESS==result || 2996==surf_id || 2997==surf_id || 3028==surf_id);
+      //assert(moab::MB_SUCCESS==result || 2996==surf_id || 2997==surf_id || 3028==surf_id);
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode test_edges() {
-    MBErrorCode result;
-    MBRange edges;
+  moab::ErrorCode test_edges() {
+    moab::ErrorCode result;
+    moab::Range edges;
     result = MBI()->get_entities_by_dimension( 0, 1, edges );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     MBI()->list_entities( edges );
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
 
@@ -363,7 +363,7 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
       std::cout << "./post_process <input_file>" << std::endl;
       return 1;
     }
-    MBErrorCode result;
+    moab::ErrorCode result;
     std::string input_name = argv[1];
 
     // The root name does not have an extension
@@ -373,59 +373,59 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
     const double MERGE_TOL = 1e-3; // should this depend on FACET_TOL? 
 
     // load the input file
-    MBEntityHandle input_meshset;
-    result = MBI()->create_meshset( MESHSET_SET, input_meshset );
-    assert(MB_SUCCESS == result);
+    moab::EntityHandle input_meshset;
+    result = MBI()->create_meshset( moab::MESHSET_SET, input_meshset );
+    assert(moab::MB_SUCCESS == result);
     if(std::string::npos != input_name.find("h5m")) {
       result = MBI()->load_file( input_name.c_str(), &input_meshset );
-      assert( MB_SUCCESS == result );
+      assert( moab::MB_SUCCESS == result );
     } else {
       std::cout << "invalid input file: must be h5m" << std::endl;
       return 1;
     }
 
     // create tags
-    MBTag geom_tag, id_tag, sense_tag, normal_tag, merge_tag;
+    moab::Tag geom_tag, id_tag, sense_tag, normal_tag, merge_tag;
     result = MBI()->tag_get_handle( GEOM_DIMENSION_TAG_NAME, sizeof(int), 
-				MB_TYPE_INTEGER, geom_tag, MB_TAG_DENSE, 0, 0 );
-    assert( MB_SUCCESS == result );
+				moab::MB_TYPE_INTEGER, geom_tag, moab::MB_TAG_DENSE, 0, 0 );
+    assert( moab::MB_SUCCESS == result );
     result = MBI()->tag_get_handle( GLOBAL_ID_TAG_NAME, sizeof(int), 
-				MB_TYPE_INTEGER, id_tag,MB_TAG_DENSE, 0, 0 );
-    assert( MB_SUCCESS == result );
-    result = MBI()->tag_get_handle( "GEOM_SENSE_2", 2*sizeof(MBEntityHandle), 
-                                MB_TYPE_HANDLE, sense_tag, MB_TAG_DENSE, 0, 0 );
-    assert( MB_SUCCESS == result );
-    result = MBI()->tag_get_handle( "NORMAL", sizeof(MBCartVect), 
-                                MB_TYPE_OPAQUE, normal_tag, MB_TAG_DENSE, 0, 0 );
-    assert( MB_SUCCESS == result );
-    result = MBI()->tag_get_handle( "MERGE", sizeof(MBEntityHandle), 
-                                MB_TYPE_HANDLE, merge_tag, MB_TAG_SPARSE, 0, 0 );
-    assert( MB_SUCCESS == result );  
+				moab::MB_TYPE_INTEGER, id_tag,moab::MB_TAG_DENSE, 0, 0 );
+    assert( moab::MB_SUCCESS == result );
+    result = MBI()->tag_get_handle( "GEOM_SENSE_2", 2*sizeof(moab::EntityHandle), 
+                                moab::MB_TYPE_HANDLE, sense_tag, moab::MB_TAG_DENSE, 0, 0 );
+    assert( moab::MB_SUCCESS == result );
+    result = MBI()->tag_get_handle( "NORMAL", sizeof(moab::CartVect), 
+                                moab::MB_TYPE_OPAQUE, normal_tag, moab::MB_TAG_DENSE, 0, 0 );
+    assert( moab::MB_SUCCESS == result );
+    result = MBI()->tag_get_handle( "MERGE", sizeof(moab::EntityHandle), 
+                                moab::MB_TYPE_HANDLE, merge_tag, moab::MB_TAG_SPARSE, 0, 0 );
+    assert( moab::MB_SUCCESS == result );  
 
     // get all geometry sets
-    MBRange geom_sets[4];
+    moab::Range geom_sets[4];
     for(unsigned dim=0; dim<4; dim++) {
       void *val[] = {&dim};
-      result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET, &geom_tag,
+      result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET, &geom_tag,
 	  					    val, 1, geom_sets[dim] );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       // make sure that sets TRACK membership and curves are ordered
-      // MESHSET_TRACK_OWNER=0x1, MESHSET_SET=0x2, MESHSET_ORDERED=0x4
-      for(MBRange::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) {
+      // moab::MESHSET_TRACK_OWNER=0x1, moab::MESHSET_SET=0x2, moab::MESHSET_ORDERED=0x4
+      for(moab::Range::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) {
         unsigned int options;
         result = MBI()->get_meshset_options(*i, options );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
     
         // if options are wrong change them
         if(dim==1) {
-          if( !(MESHSET_TRACK_OWNER&options) || !(MESHSET_ORDERED&options) ) {
-	    result = MBI()->set_meshset_options(*i, MESHSET_TRACK_OWNER|MESHSET_ORDERED);
-            assert(MB_SUCCESS == result);
+          if( !(moab::MESHSET_TRACK_OWNER&options) || !(moab::MESHSET_ORDERED&options) ) {
+	    result = MBI()->set_meshset_options(*i, moab::MESHSET_TRACK_OWNER|moab::MESHSET_ORDERED);
+            assert(moab::MB_SUCCESS == result);
           }
         } else {
-          if( !(MESHSET_TRACK_OWNER&options) ) {        
-	    result = MBI()->set_meshset_options(*i, MESHSET_TRACK_OWNER);
-            assert(MB_SUCCESS == result);
+          if( !(moab::MESHSET_TRACK_OWNER&options) ) {        
+	    result = MBI()->set_meshset_options(*i, moab::MESHSET_TRACK_OWNER);
+            assert(moab::MB_SUCCESS == result);
           }
         }
       }
@@ -435,15 +435,15 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
               << geom_sets[1].size() << " curves" << std::endl;  
 
     result = cleanup::delete_small_edges(geom_sets[2], MERGE_TOL);
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
   
     std::string output_filename = root_name + "_tri.h5m";
-    // PROBLEM: If I write the input meshset the writer returns MB_FAILURE.
+    // PROBLEM: If I write the input meshset the writer returns moab::MB_FAILURE.
     // This happens only if I delete vertices when merging.
     // result = MBI()->write_mesh( filename_new.c_str(), &input_meshset, 1);
     result = MBI()->write_mesh( output_filename.c_str() );
-    if (MB_SUCCESS != result) std::cout << "result= " << result << std::endl;
-    assert(MB_SUCCESS == result);
+    if (moab::MB_SUCCESS != result) std::cout << "result= " << result << std::endl;
+    assert(moab::MB_SUCCESS == result);
 
     zip_time = clock();
     std::cout << "zipping took " << (double) (zip_time-prep_time)/CLOCKS_PER_SEC 
@@ -452,8 +452,8 @@ MBErrorCode prepare_surfaces(MBRange &surface_sets,
     return 0;  
   }
 
-  MBInterface *MBI() {
-    static MBCore instance;
+  moab::Interface *MBI() {
+    static moab::Core instance;
     return &instance;
   }
 

--- a/make_watertight/test/Makefile
+++ b/make_watertight/test/Makefile
@@ -34,21 +34,18 @@ test_cyl: test_cyl.o gen.o arc.o zip.o cleanup.o cw_func.o mw_func.o
 	$(CC) $(LD_FLAGS) -o test_cyl test_cyl.o gen.o arc.o zip.o cleanup.o cw_func.o  \
 	mw_func.o ${MOAB_LIBS_LINK} -ldagmc
 
-test_iter : test_iter.o gen.o arc.o zip.o cleanup.o cw_func.o mw_func.o
+test_iter: test_iter.o gen.o arc.o zip.o cleanup.o cw_func.o mw_func.o
 	$(CC) $(LD_FLAGS) -o test_iter test_iter.o gen.o arc.o zip.o cleanup.o cw_func.o  \
 	mw_func.o ${MOAB_LIBS_LINK} -ldagmc
 
-test_bllite : test_bllite.o gen.o arc.o zip.o cleanup.o cw_func.o mw_func.o
+test_bllite: test_bllite.o gen.o arc.o zip.o cleanup.o cw_func.o mw_func.o
 	$(CC) $(LD_FLAGS) -o test_bllite test_bllite.o gen.o arc.o zip.o cleanup.o cw_func.o  \
 	mw_func.o ${MOAB_LIBS_LINK} -ldagmc
 
-test_iter : test_iter.o gen.o arc.o zip.o cleanup.o cw_func.o mw_func.o
-	$(CC) $(LD_FLAGS) -o test_iter test_iter.o gen.o arc.o zip.o cleanup.o cw_func.o  \
+test_fnsf_360: test_fnsf_360.o gen.o arc.o zip.o cleanup.o cw_func.o mw_func.o
+	$(CC) $(LD_FLAGS) -o test_fnsf_360 test_fnsf_360.o gen.o arc.o zip.o cleanup.o cw_func.o  \
 	mw_func.o ${MOAB_LIBS_LINK} -ldagmc
 
-test_bllite : test_bllite.o gen.o arc.o zip.o cleanup.o cw_func.o mw_func.o
-	$(CC) $(LD_FLAGS) -o test_bllite test_bllite.o gen.o arc.o zip.o cleanup.o cw_func.o  \
-	mw_func.o ${MOAB_LIBS_LINK} -ldagmc
 clean:
 	rm -f make_watertight.o make_watertight gen.o arc.o zip.o \
 	cleanup.o post_process.o post_process cw_func.o mw_fix mw_fix.o test_cyl test_cyl.o mw_func.o \

--- a/make_watertight/test/Makefile
+++ b/make_watertight/test/Makefile
@@ -49,4 +49,4 @@ test_fnsf_360: test_fnsf_360.o gen.o arc.o zip.o cleanup.o cw_func.o mw_func.o
 clean:
 	rm -f make_watertight.o make_watertight gen.o arc.o zip.o \
 	cleanup.o post_process.o post_process cw_func.o mw_fix mw_fix.o test_cyl test_cyl.o mw_func.o \
-	test_iter test_bllite test_iter.o test_bllite.o
+	test_iter test_bllite test_iter.o test_bllite.o test_fnsf_360.o test_fnsf_360

--- a/make_watertight/test/test_fnsf_360.cpp
+++ b/make_watertight/test/test_fnsf_360.cpp
@@ -1,0 +1,162 @@
+///
+/// This program was written to test the sealing of blanket lite model for the iter facility. 
+/// input: bllite20matls.h5m file (found in ../make_watertight/test/)
+/// output: pass/fail for complete sealing of the bllite model
+
+#include <iostream>
+#include <cmath>
+#include <cstdlib>
+#include <ctime>
+#include <vector>
+#include <set>
+#include <algorithm>
+#include "MBCore.hpp"
+#include "MBTagConventions.hpp"
+#include "MBRange.hpp"
+#include "MBSkinner.hpp"
+
+#include "mw_func.hpp"
+#include "cw_func.hpp"
+#include "gen.hpp"
+#include "arc.hpp"
+#include "zip.hpp"
+
+MBInterface *MBI();
+
+
+int main(int argc, char **argv)
+{
+
+//open moab instance
+MBInterface *MBI();
+
+//for unit testing purposes, we don't care about the output. Just PASS or FAIL. 
+bool verbose=false;
+
+// ******************************************************************
+  // Load the h5m file and create tags.
+  // ******************************************************************
+
+  clock_t start_time;
+  start_time = clock();
+  
+
+  // load file and get tolerance from input argument
+  MBErrorCode result;
+  std::string filename = "model1_360_1.h5m"; //set filename
+  MBEntityHandle input_set;
+  result = MBI()->create_meshset( MESHSET_SET, input_set ); //create handle to meshset
+  if(MB_SUCCESS != result) 
+    {
+      return result;
+    }
+
+result = MBI()->load_file( filename.c_str(), &input_set ); //load the file into the meshset
+  if(MB_SUCCESS != result) 
+    {
+      // failed to load the file
+      std::cout << "could not load file" << std::endl;
+      return result;
+    }
+
+  /// get faceting tolerance ////
+  double facet_tolerance;
+
+  MBTag faceting_tol_tag;
+  //get faceting tolerance handle from file
+  result = MBI()->tag_get_handle( "FACETING_TOL", 1, MB_TYPE_DOUBLE,
+        faceting_tol_tag , moab::MB_TAG_SPARSE|moab::MB_TAG_CREAT );
+  if(gen::error(MB_SUCCESS!=result, "could not get the faceting tag handle")) return result;
+  
+  //get the faceting tolerance of any entity
+  MBRange file_set;
+  result = MBI()->get_entities_by_type_and_tag( 0, MBENTITYSET, 
+                        &faceting_tol_tag, NULL, 1, file_set );
+
+  //get facetint tolerance value
+  result = MBI()->tag_get_data( faceting_tol_tag, &file_set.front(), 1, &facet_tolerance );
+  if(gen::error(MB_SUCCESS!=result, "could not get the faceting tolerance")) return result; 
+
+  // create tags on geometry
+  MBTag geom_tag, id_tag;
+  result = MBI()->tag_get_handle( GEOM_DIMENSION_TAG_NAME, 1, 
+                            MB_TYPE_INTEGER, geom_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT );
+  if(gen::error(MB_SUCCESS != result, "could not get GEOM_DIMENSION_TAG_NAME handle")) return result; 
+
+  result = MBI()->tag_get_handle( GLOBAL_ID_TAG_NAME, 1, 
+                            MB_TYPE_INTEGER, id_tag, moab::MB_TAG_DENSE|moab::MB_TAG_CREAT );
+  if(gen::error(MB_SUCCESS != result, "could not get GLOBAL_ID_TAG_NAME handle")) return result;
+  
+  // get surface and volume sets
+  MBRange surf_sets, vol_sets; // MBRange of set of surfaces and volumes
+  // surface sets
+  int dim = 2;
+  void* input_dim[] = {&dim};
+  result = MBI()->get_entities_by_type_and_tag( input_set, MBENTITYSET, &geom_tag, 
+                                                input_dim, 1, surf_sets);
+  if(MB_SUCCESS != result) 
+    {
+      return result;
+    }
+
+  // volume sets
+  dim = 3;
+  result = MBI()->get_entities_by_type_and_tag( input_set, MBENTITYSET, &geom_tag, 
+                                                input_dim, 1, vol_sets);
+  if(MB_SUCCESS != result)
+    {
+      return result;
+    }
+    
+  //vertex sets
+  dim= 0;
+  MBRange verts;
+  result = MBI()->get_entities_by_dimension(input_set, dim, verts, false);
+  if(gen::error(MB_SUCCESS!=result, " could not get vertices from the mesh")) return result;
+  
+  if(gen::error(MB_SUCCESS!=result, "could not get vertex coordinates")) return result; 
+  
+if(verbose)
+{
+  std::cout<< "number of verticies= " << verts.size() << std::endl;  
+  std::cout<< "number of surfaces= " << surf_sets.size() << std::endl;
+  std::cout<< "number of volumes= "  << vol_sets.size() << std::endl;
+}
+
+//initialize booleans to pass to make_mesh_watertight
+
+  bool check_topology, test, sealed;
+       check_topology=false;
+       test=true;
+  
+// initialize boolean for each set of tests
+  bool test_set_result=true;
+
+
+//seal mesh and make sure it is entirely sealed
+
+// seal the model using make_watertight 
+  result=mw_func::make_mesh_watertight (input_set, facet_tolerance, false);
+  if(gen::error(MB_SUCCESS!=result, "could not make the mesh watertight")) return result;
+  
+  // Lastly Check to see if make_watertight fixed the model
+  result=cw_func::check_mesh_for_watertightness( input_set, facet_tolerance, sealed, test);
+  if(gen::error(MB_SUCCESS!=result, "could not check model for watertightness")) return result;
+  
+  if(sealed)
+  {
+   std::cout << "PASS" << std::endl;
+  }
+  else
+  {
+   std::cout << "FAIL" << std::endl;
+   test_set_result=false;
+  }
+
+ exit(0);
+}
+
+MBInterface* MBI() {
+ static MBCore instance;
+ return &instance;
+}

--- a/make_watertight/zip.cpp
+++ b/make_watertight/zip.cpp
@@ -6,7 +6,8 @@ namespace zip {
   MBErrorCode t_joint( MBTag normal_tag,
                        const MBEntityHandle vert0,
                        const MBEntityHandle vert1,
-                       const MBEntityHandle vert2 ) {
+                       const MBEntityHandle vert2,
+                       bool debug ) {
     struct triangles {
       MBEntityHandle before_tri;
       const MBEntityHandle *before;
@@ -45,7 +46,7 @@ namespace zip {
   
       // Check to make sure we found a set     
       if(1 != surf_sets.size()) {
-	std::cout << "    t_joint: " << surf_sets.size() << " surface sets found for triangle " 
+	if(debug) std::cout << "    t_joint: " << surf_sets.size() << " surface sets found for triangle " 
                   << joints[i].before_tri << std::endl;
         assert(1 == surf_sets.size());
 	//if(1!=surf_sets.size()) return MB_FAILURE;
@@ -65,7 +66,7 @@ namespace zip {
    
       // test to make sure not degenerate
       //if(conn[0]==conn[1] || conn[1]==conn[2] || conn[2]==conn[0]) {
-      if( gen::triangle_degenerate( joints[i].before_tri )) {
+      if( gen::triangle_degenerate( joints[i].before_tri ) && debug ) {
         std::cout << "    t_joint: degenerate input triangle" << std::endl;
         gen::print_triangle( joints[i].before_tri, false);
         return MB_FAILURE;
@@ -80,7 +81,7 @@ namespace zip {
       // test to make sure not degenerate
       //if(conn0[0]==conn0[1] || conn0[1]==conn0[2] || conn0[2]==conn0[0]) {
       if(gen::triangle_degenerate( joints[i].after0[0], joints[i].after0[1], 
-                                                        joints[i].after0[2])) {
+                                                        joints[i].after0[2]) && debug ) {
 	std::cout << "    t_joint: degenerate output triangle 1" << std::endl;	
         gen::print_triangle( joints[i].before_tri, false );
 	//	return MB_FAILURE;
@@ -88,7 +89,7 @@ namespace zip {
       // test to make sure not degenerate
       //if(conn1[0]==conn1[1] || conn1[1]==conn1[2] || conn1[2]==conn1[0]) {
       if(gen::triangle_degenerate( joints[i].after1[0], joints[i].after1[1], 
-                                                        joints[i].after1[2])) {
+                                                        joints[i].after1[2]) && debug) {
 	std::cout << "    t_joint: degenerate output triangle 2" << std::endl;
         gen::print_triangle( joints[i].before_tri, false );
 	//gen::print_triangle( *i, true );

--- a/make_watertight/zip.cpp
+++ b/make_watertight/zip.cpp
@@ -1,22 +1,22 @@
 #include <iostream>
 #include "zip.hpp"
-#include "MBOrientedBoxTreeTool.hpp"
+#include "moab/OrientedBoxTreeTool.hpp"
 
 namespace zip {
-  MBErrorCode t_joint( MBTag normal_tag,
-                       const MBEntityHandle vert0,
-                       const MBEntityHandle vert1,
-                       const MBEntityHandle vert2,
+  moab::ErrorCode t_joint( moab::Tag normal_tag,
+                       const moab::EntityHandle vert0,
+                       const moab::EntityHandle vert1,
+                       const moab::EntityHandle vert2,
                        bool debug ) {
     struct triangles {
-      MBEntityHandle before_tri;
-      const MBEntityHandle *before;
-      MBCartVect     before_norm;
-      MBEntityHandle after0[3];
-      MBEntityHandle after1[3];
-      MBCartVect     after0_norm;
-      MBCartVect     after1_norm;
-      MBEntityHandle surf_set;
+      moab::EntityHandle before_tri;
+      const moab::EntityHandle *before;
+      moab::CartVect     before_norm;
+      moab::EntityHandle after0[3];
+      moab::EntityHandle after1[3];
+      moab::CartVect     after0_norm;
+      moab::CartVect     after1_norm;
+      moab::EntityHandle surf_set;
     };   
 
     // Get all of the old information before changing anything. 
@@ -25,11 +25,11 @@ namespace zip {
     // get the edge
 
     // get endpoints of the edge
-    MBErrorCode result;
-    MBEntityHandle endpts[2] = { vert0, vert2 }; 
-    MBRange tris;
+    moab::ErrorCode result;
+    moab::EntityHandle endpts[2] = { vert0, vert2 }; 
+    moab::Range tris;
     result = MBI()->get_adjacencies( endpts, 2, 2, true, tris );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     //std::cout << "t_joint: tris.size()=" << tris.size() << std::endl;
     //MBI()->list_entities( tris );
 
@@ -38,9 +38,9 @@ namespace zip {
       joints[i].before_tri = tris[i];
 
       // Find the surface set that the tri is in.
-      MBRange surf_sets;
+      moab::Range surf_sets;
       result = MBI()->get_adjacencies( &joints[i].before_tri, 1, 4, false, surf_sets);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       //std::cout << "t_joint: " << surf_sets.size() << " surface sets found for triangle" 
       //        << std::endl;
   
@@ -49,7 +49,7 @@ namespace zip {
 	if(debug) std::cout << "    t_joint: " << surf_sets.size() << " surface sets found for triangle " 
                   << joints[i].before_tri << std::endl;
         assert(1 == surf_sets.size());
-	//if(1!=surf_sets.size()) return MB_FAILURE;
+	//if(1!=surf_sets.size()) return moab::MB_FAILURE;
       }
       joints[i].surf_set = surf_sets.front();
       //std::cout << "t_joint: surf id=" << gen::geom_id_by_handle( joints[i].surf_set )
@@ -59,8 +59,8 @@ namespace zip {
       // get old  connectivity
       int n_verts;
       result = MBI()->get_connectivity( joints[i].before_tri, joints[i].before, n_verts);
-      if(MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
-      assert(MB_SUCCESS == result);
+      if(moab::MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
+      assert(moab::MB_SUCCESS == result);
       if(3 != n_verts) std::cout << "n_verts=" << n_verts << std::endl;
       assert(3 == n_verts);
    
@@ -69,7 +69,7 @@ namespace zip {
       if( gen::triangle_degenerate( joints[i].before_tri ) && debug ) {
         std::cout << "    t_joint: degenerate input triangle" << std::endl;
         gen::print_triangle( joints[i].before_tri, false);
-        return MB_FAILURE;
+        return moab::MB_FAILURE;
       }
 
       // make new connectivity
@@ -84,7 +84,7 @@ namespace zip {
                                                         joints[i].after0[2]) && debug ) {
 	std::cout << "    t_joint: degenerate output triangle 1" << std::endl;	
         gen::print_triangle( joints[i].before_tri, false );
-	//	return MB_FAILURE;
+	//	return moab::MB_FAILURE;
       }
       // test to make sure not degenerate
       //if(conn1[0]==conn1[1] || conn1[1]==conn1[2] || conn1[2]==conn1[0]) {
@@ -93,112 +93,112 @@ namespace zip {
 	std::cout << "    t_joint: degenerate output triangle 2" << std::endl;
         gen::print_triangle( joints[i].before_tri, false );
 	//gen::print_triangle( *i, true );
-	//return MB_FAILURE;
+	//return moab::MB_FAILURE;
       }
 
       // set the new connectivity on the original triangle
       result = MBI()->set_connectivity( joints[i].before_tri, joints[i].after0, 3 );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       // set the new connectivity on the new triangle
-      MBEntityHandle new_tri;
-      result = MBI()->create_element( MBTRI, joints[i].after1, 3, new_tri );
-      assert(MB_SUCCESS == result);
+      moab::EntityHandle new_tri;
+      result = MBI()->create_element( moab::MBTRI, joints[i].after1, 3, new_tri );
+      assert(moab::MB_SUCCESS == result);
 
       // copy the original normal to the new triangle
-      MBCartVect normal;
+      moab::CartVect normal;
       result = MBI()->tag_get_data( normal_tag, &joints[i].before_tri, 1, &normal);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       result = MBI()->tag_set_data( normal_tag, &new_tri, 1, &normal);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
     
       // add the new triangle to the same surface set as the original
       result = MBI()->add_entities( joints[i].surf_set, &new_tri, 1);
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
 
       // catch-all to remove degenerate tris
       result = zip::delete_degenerate_tris( joints[i].before_tri );
-      if(gen::error(MB_SUCCESS!=result,"could not delete degenerate tri")) return result;
+      if(gen::error(moab::MB_SUCCESS!=result,"could not delete degenerate tri")) return result;
       result = zip::delete_degenerate_tris( new_tri );
-      if(gen::error(MB_SUCCESS!=result,"could not delete degenerate tri")) return result;
+      if(gen::error(moab::MB_SUCCESS!=result,"could not delete degenerate tri")) return result;
 
       //gen::print_triangle( tri, false );
       //gen::print_triangle( new_tri, false );
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
   // Delete degenerate triangles in the range.
-  MBErrorCode delete_degenerate_tris( MBEntityHandle tri ) {
-    MBErrorCode result;
-    const MBEntityHandle *con;
+  moab::ErrorCode delete_degenerate_tris( moab::EntityHandle tri ) {
+    moab::ErrorCode result;
+    const moab::EntityHandle *con;
     int n_verts;
     result = MBI()->get_connectivity( tri, con, n_verts);
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     assert(3 == n_verts);
     if(con[0]==con[1] || con[1]==con[2] || con[2]==con[0]) {
       //std::cout << "delete_degenerate_tris: degenerate triangle=" << tri << " deleted" << std::endl;
       result = MBI()->delete_entities( &tri, 1 );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
-  MBErrorCode delete_degenerate_tris( MBRange tris ) {
-    MBErrorCode result;
-    for(MBRange::iterator i=tris.begin(); i!=tris.end(); i++) {
+  moab::ErrorCode delete_degenerate_tris( moab::Range tris ) {
+    moab::ErrorCode result;
+    for(moab::Range::iterator i=tris.begin(); i!=tris.end(); i++) {
       result = delete_degenerate_tris( *i );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
 
-  MBErrorCode delete_adj_degenerate_tris( const MBEntityHandle adj_vert ) {
+  moab::ErrorCode delete_adj_degenerate_tris( const moab::EntityHandle adj_vert ) {
     // get the adjacent triangles
-    MBErrorCode result;
-    MBRange tris;
+    moab::ErrorCode result;
+    moab::Range tris;
     result = MBI()->get_adjacencies( &adj_vert, 1, 2, false, tris );
-    assert(MB_SUCCESS == result);
+    assert(moab::MB_SUCCESS == result);
     result = delete_degenerate_tris( tris );
-    assert(MB_SUCCESS == result);
-    return MB_SUCCESS;
+    assert(moab::MB_SUCCESS == result);
+    return moab::MB_SUCCESS;
   }
 
   // Problem: MOAB can check for degenerate tris and delete them.
   // MOAB check the curves and arcs passed in to update the merged vertex, but
   // still ends up with degenerate edges. The curves that are in MOAB as sets
   // are updated but also contain degenerate edges due to merging.
-  MBErrorCode merge_verts( const MBEntityHandle keep_vert, 
-                           const MBEntityHandle delete_vert,
-                           std::vector<MBEntityHandle> &arc0,
-                           std::vector<MBEntityHandle> &arc1 ) {
+  moab::ErrorCode merge_verts( const moab::EntityHandle keep_vert, 
+                           const moab::EntityHandle delete_vert,
+                           std::vector<moab::EntityHandle> &arc0,
+                           std::vector<moab::EntityHandle> &arc1 ) {
 
-    MBErrorCode rval;
+    moab::ErrorCode rval;
     // first update the arcs with the keep_vert
-    for(std::vector<MBEntityHandle>::iterator i=arc0.begin(); i!=arc0.end(); ++i) {
+    for(std::vector<moab::EntityHandle>::iterator i=arc0.begin(); i!=arc0.end(); ++i) {
       if(delete_vert == *i) *i = keep_vert;
     }
-    for(std::vector<MBEntityHandle>::iterator i=arc1.begin(); i!=arc1.end(); ++i) {
+    for(std::vector<moab::EntityHandle>::iterator i=arc1.begin(); i!=arc1.end(); ++i) {
       if(delete_vert == *i) *i = keep_vert;
     }
 
     // UPDATE: This is slower than using the O(n) linear search above.
     // Let moab update adjacencies. Unless moab stores data is must be 
     // merge-updated manually to prevent stale handles.
-    /*    MBEntityHandle arc0_set, arc1_set;
+    /*    moab::EntityHandle arc0_set, arc1_set;
     rval = MBI()->create_meshset( MESHSET_TRACK_OWNER|MESHSET_ORDERED, arc0_set );
-    if(gen::error(MB_SUCCESS!=rval,"creating arc0_set failed")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"creating arc0_set failed")) return rval;
     rval = MBI()->create_meshset( MESHSET_TRACK_OWNER|MESHSET_ORDERED, arc1_set );
-    if(gen::error(MB_SUCCESS!=rval,"creating arc1_set failed")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"creating arc1_set failed")) return rval;
     rval = arc::set_meshset( arc0_set, arc0 );                                          
-    if(gen::error(MB_SUCCESS!=rval,"setting arc0_set failed")) return rval; 
+    if(gen::error(moab::MB_SUCCESS!=rval,"setting arc0_set failed")) return rval; 
     rval = arc::set_meshset( arc1_set, arc1 );                                          
-    if(gen::error(MB_SUCCESS!=rval,"setting arc1_set failed")) return rval; 
+    if(gen::error(moab::MB_SUCCESS!=rval,"setting arc1_set failed")) return rval; 
     */
 
     // get adjacent tris
-    MBRange tris;
-    MBEntityHandle verts[2]={keep_vert, delete_vert};
-    rval = MBI()->get_adjacencies( verts, 2, 2, false, tris, MBInterface::UNION );
-    if(gen::error(MB_SUCCESS!=rval,"getting adjacent tris failed")) return rval;
+    moab::Range tris;
+    moab::EntityHandle verts[2]={keep_vert, delete_vert};
+    rval = MBI()->get_adjacencies( verts, 2, 2, false, tris, moab::Interface::UNION );
+    if(gen::error(moab::MB_SUCCESS!=rval,"getting adjacent tris failed")) return rval;
     //if(0 == tris.size()) {
     //  std::cout << "merge_verts: cannot find any triangles adjacent to vertices" << std::endl;
     //  return MB_ENTITY_NOT_FOUND;
@@ -207,76 +207,76 @@ namespace zip {
 
     // actually do the merge
     rval = MBI()->merge_entities( keep_vert, delete_vert, false, true );
-    if(gen::error(MB_SUCCESS!=rval,"merge entities failed")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"merge entities failed")) return rval;
     //std::cout << "  tris.size()=" << tris.size() << std::endl;
 
     // delete degenerate tris
     rval = delete_degenerate_tris( tris );
-    if(gen::error(MB_SUCCESS!=rval,"deleting degenerate tris failed")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"deleting degenerate tris failed")) return rval;
 
     // Get the merge-updated arcs back.
     /*    rval = arc::get_meshset( arc0_set, arc0 ); 
-    if(gen::error(MB_SUCCESS!=rval,"getting arc0 set failed")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"getting arc0 set failed")) return rval;
     rval = arc::get_meshset( arc1_set, arc1 ); 
-    if(gen::error(MB_SUCCESS!=rval,"getting arc1 set failed")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"getting arc1 set failed")) return rval;
     rval = MBI()->delete_entities( &arc0_set, 1 );                   
-    if(gen::error(MB_SUCCESS!=rval,"deleting arc0_set failed")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"deleting arc0_set failed")) return rval;
     rval = MBI()->delete_entities( &arc1_set, 1 );                   
-    if(gen::error(MB_SUCCESS!=rval,"deleting arc1_set failed")) return rval;
+    if(gen::error(moab::MB_SUCCESS!=rval,"deleting arc1_set failed")) return rval;
     */
 
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }                           
 
   // Test to make sure the triangle normal vectors have not been inverted.
-  MBErrorCode test_normals( const std::vector<MBCartVect> norms0,
-                            const std::vector<MBCartVect> norms1,
+  moab::ErrorCode test_normals( const std::vector<moab::CartVect> norms0,
+                            const std::vector<moab::CartVect> norms1,
                             std::vector<int> &inverted_tri_indices ) {
     assert(norms0.size() == norms1.size());
     for(unsigned int i=0; i<norms0.size(); i++) {
-      MBErrorCode result = test_normals( norms0[i], norms1[i]);
-      if(MB_SUCCESS != result) {
+      moab::ErrorCode result = test_normals( norms0[i], norms1[i]);
+      if(moab::MB_SUCCESS != result) {
         //std::cout << "test_normals: failed on i=" << i << std::endl;
         inverted_tri_indices.push_back(i);
       }
     }
-    return MB_SUCCESS;
+    return moab::MB_SUCCESS;
   }
-  MBErrorCode test_normals( const MBCartVect norm0, const MBCartVect norm1 ) {
+  moab::ErrorCode test_normals( const moab::CartVect norm0, const moab::CartVect norm1 ) {
     if(0 > norm0 % norm1) {
       //std::cout << "test_normals: tri is inverted, dot product=" 
       //          << norm0 % norm1 << std::endl;
-      return MB_FAILURE;
+      return moab::MB_FAILURE;
     } else {
-      return MB_SUCCESS;
+      return moab::MB_SUCCESS;
     }
   }
 
   /* Accepts a range of inverted tris. Refacets affected surface so that no tris
      are inverted. */
-  MBErrorCode remove_inverted_tris(MBTag normal_tag, MBRange tris, const bool debug ) {
+  moab::ErrorCode remove_inverted_tris(moab::Tag normal_tag, moab::Range tris, const bool debug ) {
       
-    MBErrorCode result;
+    moab::ErrorCode result;
     bool failures_occur = false;
     while(!tris.empty()) {
 
       /* Get a group of triangles to re-facet. They must be adjacent to each other
 	 and in the same surface. */
-      MBRange tris_to_refacet;
+      moab::Range tris_to_refacet;
       tris_to_refacet.insert( tris.front() );
-      MBRange surf_set;
+      moab::Range surf_set;
       result = MBI()->get_adjacencies( tris_to_refacet, 4, false, surf_set );
-      assert(MB_SUCCESS == result);
+      assert(moab::MB_SUCCESS == result);
       if(1 != surf_set.size()) {
 	std::cout << "remove_inverted_tris: tri is in " << surf_set.size() 
                   << " surfaces" << std::endl;
-        return MB_FAILURE;
+        return moab::MB_FAILURE;
       }
 
       // get all tris in the surface
-      MBRange surf_tris;
-      result = MBI()->get_entities_by_type( surf_set.front(), MBTRI, surf_tris );
-      assert(MB_SUCCESS == result); 
+      moab::Range surf_tris;
+      result = MBI()->get_entities_by_type( surf_set.front(), moab::MBTRI, surf_tris );
+      assert(moab::MB_SUCCESS == result); 
 
       /* Find all of the adjacent inverted triangles of the same surface. Keep
 	 searching until a search returns no new triangles. */
@@ -286,17 +286,17 @@ namespace zip {
         // Here edges are being created. Remember to delete them. Outside of this
         // function. Skinning gets bogged down if unused MBEdges (from other 
         // surfaces) accumulate.
-        MBRange tri_edges;
+        moab::Range tri_edges;
         result = MBI()->get_adjacencies( tris_to_refacet, 1, true, tri_edges,
-                                         MBInterface::UNION );
-        assert(MB_SUCCESS == result);
-        MBRange connected_tris;
+                                         moab::Interface::UNION );
+        assert(moab::MB_SUCCESS == result);
+        moab::Range connected_tris;
         result = MBI()->get_adjacencies( tri_edges, 2, false, connected_tris, 
-                                         MBInterface::UNION );
-        assert(MB_SUCCESS == result);
+                                         moab::Interface::UNION );
+        assert(moab::MB_SUCCESS == result);
         result = MBI()->delete_entities( tri_edges );
-        assert(MB_SUCCESS == result);
-        MBRange tris_to_refacet2 = intersect( tris_to_refacet, connected_tris );
+        assert(moab::MB_SUCCESS == result);
+        moab::Range tris_to_refacet2 = intersect( tris_to_refacet, connected_tris );
         tris_to_refacet2 = intersect( tris_to_refacet, surf_tris );
 
         if(tris_to_refacet.size() == tris_to_refacet2.size()) search_again = false;
@@ -307,9 +307,9 @@ namespace zip {
       tris = subtract( tris, tris_to_refacet );
 
         // do edges already exist?
-	MBRange temp;
-          result = MBI()->get_entities_by_type(0, MBEDGE, temp );
-          assert(MB_SUCCESS == result);
+	moab::Range temp;
+          result = MBI()->get_entities_by_type(0, moab::MBEDGE, temp );
+          assert(moab::MB_SUCCESS == result);
           if(!temp.empty()) MBI()->list_entities( temp );
 	  assert(temp.empty());
 
@@ -319,8 +319,8 @@ namespace zip {
       while(true) {
         // do edges already exist?
 	temp.clear();
-          result = MBI()->get_entities_by_type(0, MBEDGE, temp );
-          assert(MB_SUCCESS == result);
+          result = MBI()->get_entities_by_type(0, moab::MBEDGE, temp );
+          assert(moab::MB_SUCCESS == result);
           if(!temp.empty()) MBI()->list_entities( temp );
 	  assert(temp.empty());
 
@@ -336,32 +336,32 @@ namespace zip {
         // THIS PROVIDES A BAD EXIT. MUST FIX
 
         // get the edges of the patch of inverted tris
-	MBRange tri_edges;
+	moab::Range tri_edges;
 	result = MBI()->get_adjacencies( tris_to_refacet, 1, true, tri_edges,
-                                         MBInterface::UNION );
-	assert(MB_SUCCESS == result);
+                                         moab::Interface::UNION );
+	assert(moab::MB_SUCCESS == result);
 
 	// get all adjacent tris to the patch of inverted tris in the surface
-	MBRange adj_tris;
+	moab::Range adj_tris;
 	result = MBI()->get_adjacencies( tri_edges, 2, false, adj_tris, 
-                                         MBInterface::UNION );
-	assert(MB_SUCCESS == result);
+                                         moab::Interface::UNION );
+	assert(moab::MB_SUCCESS == result);
         result = MBI()->delete_entities( tri_edges );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
 	tris_to_refacet = intersect( surf_tris, adj_tris );
         if(tris_to_refacet.empty()) continue;
 	//gen::print_triangles( tris_to_refacet );    
 	
 	// get an area-weighted normal of the adj_tris
-	MBCartVect plane_normal(0,0,0);
+	moab::CartVect plane_normal(0,0,0);
 	//for(unsigned int i=0; i<tris_to_refacet.size(); i++) {
-	for(MBRange::iterator i=tris_to_refacet.begin(); i!=tris_to_refacet.end(); i++) {
-	  MBCartVect norm;
+	for(moab::Range::iterator i=tris_to_refacet.begin(); i!=tris_to_refacet.end(); i++) {
+	  moab::CartVect norm;
 	  result = MBI()->tag_get_data( normal_tag, &(*i), 1, &norm);
-	  assert(MB_SUCCESS == result);
+	  assert(moab::MB_SUCCESS == result);
 	  double area;
           result = gen::triangle_area( *i, area );
-          assert(MB_SUCCESS == result);
+          assert(moab::MB_SUCCESS == result);
 	  if(debug) std::cout << "norm=" << norm << " area=" << area << std::endl;
 	  //plane_normal += norm*area;
 	  plane_normal += norm;
@@ -370,22 +370,22 @@ namespace zip {
 
         // do edges already exist?
 	temp.clear();
-          result = MBI()->get_entities_by_type(0, MBEDGE, temp );
-          assert(MB_SUCCESS == result);
+          result = MBI()->get_entities_by_type(0, moab::MBEDGE, temp );
+          assert(moab::MB_SUCCESS == result);
           if(!temp.empty()) MBI()->list_entities( temp );
 	  assert(temp.empty());
  
 	// skin the tris
-	MBRange unordered_edges;
+	moab::Range unordered_edges;
 	//MBSkinner tool(MBI());
 	//result = tool.find_skin( tris_to_refacet, 1, unordered_edges, false );
 	result = gen::find_skin( tris_to_refacet, 1, unordered_edges, false );
-	assert(MB_SUCCESS == result);
+	assert(moab::MB_SUCCESS == result);
         if(unordered_edges.empty()) {
         // do edges already exist?
-          MBRange temp;
-          result = MBI()->get_entities_by_type(0, MBEDGE, temp );
-          assert(MB_SUCCESS == result);
+          moab::Range temp;
+          result = MBI()->get_entities_by_type(0, moab::MBEDGE, temp );
+          assert(moab::MB_SUCCESS == result);
           if(!temp.empty()) MBI()->list_entities( temp );
 	  assert(temp.empty());
           continue;
@@ -394,21 +394,21 @@ namespace zip {
 	//std::cout << "remove_inverted_tris: surf_id=" 
 	//  << gen::geom_id_by_handle(surf_set.front()) << std::endl;
 	//result = MBI()->list_entities( tris_to_refacet );
-	//assert(MB_SUCCESS == result);
+	//assert(moab::MB_SUCCESS == result);
 
 	// assemble into a polygon
-	std::vector<MBEntityHandle> polygon_of_verts;
+	std::vector<moab::EntityHandle> polygon_of_verts;
 	result = arc::order_verts_by_edge( unordered_edges, polygon_of_verts );
 	if(debug) gen::print_loop( polygon_of_verts ); 
-	//assert(MB_SUCCESS == result);
-	if(MB_SUCCESS != result) {
+	//assert(moab::MB_SUCCESS == result);
+	if(moab::MB_SUCCESS != result) {
 	  if(debug) std::cout << "remove_inverted_tris: couldn't order polygon by edge" << std::endl;
-	  return MB_FAILURE;
+	  return moab::MB_FAILURE;
 	}
 
         // remember to remove edges
         result = MBI()->delete_entities( unordered_edges );
-        assert(MB_SUCCESS == result);
+        assert(moab::MB_SUCCESS == result);
 
 	// remove the duplicate endpt
 	polygon_of_verts.pop_back();
@@ -416,21 +416,21 @@ namespace zip {
 	// the polygon should have at least 3 verts
 	if(3 > polygon_of_verts.size()) {
 	  if(debug) std::cout << "remove_inverted_tris: polygon has too few points" << std::endl;
-	  return MB_FAILURE;
+	  return moab::MB_FAILURE;
 	}
 
 	// orient the polygon with the triangles (could be backwards)
 	// get the first adjacent tri
-	MBEntityHandle edge[2] = { polygon_of_verts[0], polygon_of_verts[1] };
-	MBRange one_tri;
+	moab::EntityHandle edge[2] = { polygon_of_verts[0], polygon_of_verts[1] };
+	moab::Range one_tri;
 	result = MBI()->get_adjacencies( edge, 2, 2, false, one_tri );
-	assert(MB_SUCCESS == result);
+	assert(moab::MB_SUCCESS == result);
 	one_tri = intersect( tris_to_refacet, one_tri );
 	assert(1 == one_tri.size());
-	const MBEntityHandle *conn;
+	const moab::EntityHandle *conn;
 	int n_conn;
 	result = MBI()->get_connectivity( one_tri.front(), conn, n_conn );
-	assert(MB_SUCCESS == result);
+	assert(moab::MB_SUCCESS == result);
 	assert(3 == n_conn);
 	if( (edge[0]==conn[1] && edge[1]==conn[0]) ||
 	    (edge[0]==conn[2] && edge[1]==conn[1]) ||
@@ -439,45 +439,45 @@ namespace zip {
 	  if(debug) std::cout << "remove_inverted_tris: polygon reversed" << std::endl;
 	}
 
-	/* facet the polygon. Returns MB_FAILURE if it fails to facet the polygon. */
-	MBRange new_tris;
+	/* facet the polygon. Returns moab::MB_FAILURE if it fails to facet the polygon. */
+	moab::Range new_tris;
 	result = gen::ear_clip_polygon( polygon_of_verts, plane_normal, new_tris );
 
         // break if the refaceting is successful
-	if(MB_SUCCESS == result) {
+	if(moab::MB_SUCCESS == result) {
           // summarize tri area
-          for(MBRange::iterator i=new_tris.begin(); i!=new_tris.end(); i++) {
+          for(moab::Range::iterator i=new_tris.begin(); i!=new_tris.end(); i++) {
             double area;
             result = gen::triangle_area( *i, area );
-            assert(MB_SUCCESS == result);
+            assert(moab::MB_SUCCESS == result);
 	    if(debug) std::cout << "  new tri area=" << area << std::endl;
           }
 
   	  // check the new normals
-	  std::vector<MBCartVect> new_normals;
+	  std::vector<moab::CartVect> new_normals;
 	  result = gen::triangle_normals( new_tris, new_normals );
-	  if(MB_SUCCESS != result) return result;
+	  if(moab::MB_SUCCESS != result) return result;
 
 	  // test the new triangles
 	  std::vector<int> inverted_tri_indices;
-	  std::vector<MBCartVect> normals ( new_normals.size(), plane_normal );
+	  std::vector<moab::CartVect> normals ( new_normals.size(), plane_normal );
 	  result = zip::test_normals( normals, new_normals, inverted_tri_indices );
-	  assert(MB_SUCCESS == result);
+	  assert(moab::MB_SUCCESS == result);
 	  if(inverted_tri_indices.empty()) {
   	    // remove the tris that were re-faceted
             tris = subtract( tris, tris_to_refacet );
   	    result = MBI()->remove_entities( surf_set.front(), tris_to_refacet );
-	    assert(MB_SUCCESS == result);
+	    assert(moab::MB_SUCCESS == result);
 	    result = MBI()->delete_entities( tris_to_refacet ); 
-	    assert(MB_SUCCESS == result);
+	    assert(moab::MB_SUCCESS == result);
 
 	    // add the new tris to the surf set
 	    result = MBI()->add_entities( surf_set.front(), new_tris );
-	    assert(MB_SUCCESS == result);
+	    assert(moab::MB_SUCCESS == result);
 
             // put the new normals on the new tris
             result = gen::save_normals( new_tris, normal_tag );
-            assert(MB_SUCCESS == result);
+            assert(moab::MB_SUCCESS == result);
 	    if(debug) std::cout << "remove_inverted_tris: success fixing a patch" << std::endl;
             break;
           }
@@ -486,14 +486,14 @@ namespace zip {
         // remember to delete the tris that were created from the failed ear clipping
         else {
           result = MBI()->delete_entities( new_tris );
-          assert(MB_SUCCESS == result);
+          assert(moab::MB_SUCCESS == result);
         }
 
         // If the entire surface could not be ear clipped, give up
         if (tris_to_refacet.size() == surf_tris.size()) {
 	  if(debug) std::cout << "remove_inverted_tris: ear clipping entire surface failed"
 			    << std::endl;
-	  return MB_FAILURE;
+	  return moab::MB_FAILURE;
 	}
 
       } // loop until the entire surface has attempted to be refaceted
@@ -501,17 +501,17 @@ namespace zip {
    
     if(failures_occur) {
       if(debug) std::cout << "remove_inverted_facets: at least one failure occured" << std::endl;
-      return MB_FAILURE;
+      return moab::MB_FAILURE;
     } else {
-      return MB_SUCCESS;
+      return moab::MB_SUCCESS;
     }
   }
 
 
     // we do not merge edges, just vert. check the verts
-  MBErrorCode test_zipping(const double FACET_TOL,
-                           const std::vector< std::vector<MBEntityHandle> > arcs ) {
-      MBErrorCode result;
+  moab::ErrorCode test_zipping(const double FACET_TOL,
+                           const std::vector< std::vector<moab::EntityHandle> > arcs ) {
+      moab::ErrorCode result;
 
       // make sure each arc has the same number of edges
       for(unsigned int i=1; i<arcs.size(); i++) {
@@ -519,7 +519,7 @@ namespace zip {
 	  std::cout << "The curve has " << arcs[0].size() << " edges but arc "
 		    << i << " has " << arcs[i].size() << " edges." << std::endl;
 	  gen::print_arcs( arcs );
-	  return MB_FAILURE;
+	  return moab::MB_FAILURE;
 	}
       }
   
@@ -529,7 +529,7 @@ namespace zip {
 	if(arcs[0][i] == arcs[0][i+1]) {
 	  std::cout << "degenerate edge at pos " << i << " and " << i+1 << " with verts "
 		    << arcs[0][i] << " and " << arcs[0][i+1] << std::endl;
-	  return MB_FAILURE;
+	  return moab::MB_FAILURE;
 	}
       
 	// check for edge of zero dist
@@ -537,7 +537,7 @@ namespace zip {
 	if(FACET_TOL >= d) {
 	  std::cout << "edge length=" << d << " betwee pos " << i << " and " << i+1
 		    << " with verts " << arcs[0][i] << " and " << arcs[0][i+1] << std::endl;
-	  return MB_FAILURE;
+	  return moab::MB_FAILURE;
 	}
      
 	// loop over every arc
@@ -546,32 +546,32 @@ namespace zip {
 	  if(arcs[0][i]!=arcs[j][i] || arcs[0][i+1]!=arcs[j][i+1]) {
 	    std::cout << "arc " << j << " vertices do not match curve vertices, pos= " 
 		      << i << "/" << arcs[j].size() << std::endl;
-	    return MB_FAILURE;
+	    return moab::MB_FAILURE;
 	  }
 	}  	
         
 	// make sure triangles have area
-	MBRange tris;
+	moab::Range tris;
 	result = MBI()->get_adjacencies( &(arcs[0][i]), 2, 2, false, tris );
-	assert(MB_SUCCESS == result);
-	for(MBRange::iterator k=tris.begin(); k!=tris.end(); k++) {
+	assert(moab::MB_SUCCESS == result);
+	for(moab::Range::iterator k=tris.begin(); k!=tris.end(); k++) {
 	  // We know that there are not degenerate edges along the curve.
 	  // Sometimes degenerate tris are created due to merging curve endpts.
 	  // here we do not remove tri from the surf meshset, but we should
 	  if( gen::triangle_degenerate(*k) ) {
 	    //result = MBI()->delete_entities( &(*k), 1);
-	    //assert(MB_SUCCESS == result);
+	    //assert(moab::MB_SUCCESS == result);
 	    std::cout << "  arc=" << 0 << " pos=" << i << " vert=" << arcs[0][i] 
 		      << " degenerate triangle" << std::endl;
 	    gen::print_triangle(*k, false);
 	    //print_edge( edge );
 	    //continue;
-	    return MB_FAILURE;
+	    return moab::MB_FAILURE;
 	  }
 
 	  double area;
           result = gen::triangle_area( *k, area );
-          assert(MB_SUCCESS == result);
+          assert(moab::MB_SUCCESS == result);
 	  // I found a valid tri on a curve with only one edge (1e-5 long)
 	  // that had an area of 1e-11.
 	  if(1e-8 > area) {
@@ -580,11 +580,11 @@ namespace zip {
 	    gen::print_triangle(*k, false);            
 	    //print_edge( edge );
   	    gen::print_arcs( arcs );
-	    //if(0.0 >= area) return MB_FAILURE;
+	    //if(0.0 >= area) return moab::MB_FAILURE;
 	  } 
 	}
       }
-      return MB_SUCCESS;
+      return moab::MB_SUCCESS;
     }          
   
   

--- a/make_watertight/zip.hpp
+++ b/make_watertight/zip.hpp
@@ -1,47 +1,47 @@
 #ifndef ZIP_HPP
 #define ZIP_HPP
 
-#include "MBCore.hpp"
+#include "moab/Core.hpp"
 #include "gen.hpp"
 #include "arc.hpp"
 
-MBInterface *MBI();
+moab::Interface *MBI();
 namespace zip {
-  MBErrorCode t_joint( MBTag normal_tag, 
-                       const MBEntityHandle vert0,              
-                       const MBEntityHandle vert1,                         
-                       const MBEntityHandle vert2,
+  moab::ErrorCode t_joint( moab::Tag normal_tag, 
+                       const moab::EntityHandle vert0,              
+                       const moab::EntityHandle vert1,                         
+                       const moab::EntityHandle vert2,
                        bool debug );
 /// removes the entitiy handle tri from the loaded mesh                
-  MBErrorCode delete_degenerate_tris( MBEntityHandle tri );
-/// checks that no triangles in the MBRange tris are degenterate. If 
+  moab::ErrorCode delete_degenerate_tris( moab::EntityHandle tri );
+/// checks that no triangles in the moab::Range tris are degenterate. If 
 /// degenerate triangles are found, they are deleted from the mesh. 
-  MBErrorCode delete_degenerate_tris( MBRange tris );
+  moab::ErrorCode delete_degenerate_tris( moab::Range tris );
 
-  MBErrorCode delete_adj_degenerate_tris( const MBEntityHandle adj_vert );
+  moab::ErrorCode delete_adj_degenerate_tris( const moab::EntityHandle adj_vert );
 
 
 /// merges two vertices by updating the entity handle of the deleted vert to the vert to 
 /// keep in the correct arc. Uses MOAB function merge_entities to merge the vertices in 
 /// the database. Also deletes the triangles adjacent to the merged vertices if one
 /// becomes degenerate.
-  MBErrorCode merge_verts( const MBEntityHandle keep_vert, 
-                           const MBEntityHandle delete_vert,
-                           std::vector<MBEntityHandle> &arc0,
-                           std::vector<MBEntityHandle> &arc1 );
+  moab::ErrorCode merge_verts( const moab::EntityHandle keep_vert, 
+                           const moab::EntityHandle delete_vert,
+                           std::vector<moab::EntityHandle> &arc0,
+                           std::vector<moab::EntityHandle> &arc1 );
 
 /// test two normal vectors to see if they point in the same direction
-  MBErrorCode test_normals( const std::vector<MBCartVect> norms0, 
-                            const std::vector<MBCartVect> norms1,
+  moab::ErrorCode test_normals( const std::vector<moab::CartVect> norms0, 
+                            const std::vector<moab::CartVect> norms1,
                             std::vector<int> &inverted_tri_indices );
-  MBErrorCode test_normals( const             MBCartVect  norms0, 
-                            const             MBCartVect  norms1 );
+  moab::ErrorCode test_normals( const             moab::CartVect  norms0, 
+                            const             moab::CartVect  norms1 );
 
-  MBErrorCode remove_inverted_tris(MBTag normal_tag, MBRange tris, const bool debug );
+  moab::ErrorCode remove_inverted_tris(moab::Tag normal_tag, moab::Range tris, const bool debug );
 
 /// tests the watertightness of all arcs in the vector-array of moab entity handles arcs
-  MBErrorCode test_zipping( const double FACET_TOL,
-                            const std::vector< std::vector<MBEntityHandle> > arcs );
+  moab::ErrorCode test_zipping( const double FACET_TOL,
+                            const std::vector< std::vector<moab::EntityHandle> > arcs );
 
 }
 

--- a/make_watertight/zip.hpp
+++ b/make_watertight/zip.hpp
@@ -10,7 +10,8 @@ namespace zip {
   MBErrorCode t_joint( MBTag normal_tag, 
                        const MBEntityHandle vert0,              
                        const MBEntityHandle vert1,                         
-                       const MBEntityHandle vert2 );
+                       const MBEntityHandle vert2,
+                       bool debug );
 /// removes the entitiy handle tri from the loaded mesh                
   MBErrorCode delete_degenerate_tris( MBEntityHandle tri );
 /// checks that no triangles in the MBRange tris are degenterate. If 


### PR DESCRIPTION
Here are updates for make_watertight so it can be built with newer versions of MOAB after the majority of the 'MB' headers have been removed.

@makeclean I mentioned replacing the asserts with the MOAB errorcode macros, but without a better test suite I'm a little nervous how the macros allow the program to continue after an error. I don't want mw to continue after one of those and do something weird to the representation of the model. That being said I do have a branch with the macros inserted and if you think its best to just bring them in now and deal problems as they arise, I'm happy with that as well.