### PR TITLE
Comment cleanup

### DIFF
--- a/make_watertight/arc.cpp
+++ b/make_watertight/arc.cpp
@@ -87,7 +87,6 @@ namespace arc {
 
     // do this in O(n) by using adjacencies instead of O(n^2)
     moab::ErrorCode result;
-    //for(moab::Range::iterator i=edges.begin(); i!=edges.end(); i++ ) {
     for(unsigned int i=0; i<edges.size(); i++) {
       moab::EntityHandle the_edge = edges[i];
 
@@ -103,8 +102,6 @@ namespace arc {
       moab::Range adj_edges;
       result = MBI()->get_adjacencies( two_verts, 1, false, adj_edges, moab::Interface::INTERSECT);
       assert(moab::MB_SUCCESS == result);
-      // remove the original edge
-      //adj_edges.erase( *i );
 
       // if any other edges exist, they are opposite the original edge and should be
       // removed from the skin
@@ -114,10 +111,6 @@ namespace arc {
                     << " opposite edges will be removed from the surface skin " 
                     << adj_edges[0] << " " << adj_edges[1] << std::endl;
 	}
-	//gen::print_range_of_edges( adj_edges );
-	//gen::print_range_of_edges( edges );
-	//edges = edges.subtract( adj_edges );
-        //edges.erase( *i );
         edges = subtract( edges, adj_edges );
         result = MBI()->delete_entities( adj_edges );
         assert(moab::MB_SUCCESS == result);
@@ -299,7 +292,6 @@ namespace arc {
     moab::ErrorCode result;
     unsigned int n_edges_in  = edges.size();
     unsigned int n_edges_out = 0;
-    //gen::print_range_of_edges( edges );
     // there could be several arcs for each surface
     while ( 0!= edges.size() ) {
       std::vector<moab::EntityHandle> loop_of_edges;
@@ -331,7 +323,6 @@ namespace arc {
 	  std::cout << "  create_loops: pinch point exists" << std::endl;
           result = MBI()->list_entity( end_verts[0] );
           assert(moab::MB_SUCCESS == result);
-          //return moab::MB_MULTIPLE_ENTITIES_FOUND;
         }
       }
 
@@ -353,7 +344,6 @@ namespace arc {
           gen::print_arc_of_edges( loop_of_edges );
           return result;
         }
-	//assert( moab::MB_SUCCESS == result );
 
 	// if the next edge was found
 	if ( 0!=next_edge ) {
@@ -366,7 +356,6 @@ namespace arc {
 	  edges.erase( next_edge );
 
 	  // set the new reference vertex
-	  //vert = next_vert;
 	  edge = next_edge;
 
 	  // if another edge was not found
@@ -434,7 +423,6 @@ namespace arc {
       result = MBI()->get_adjacencies( &vert, 1, 1, false, adj_edges );
       assert(moab::MB_SUCCESS == result);
       adj_edges = intersect( adj_edges, unordered_edges );
-      //assert(!adj_edges.empty());
       if(adj_edges.empty()) {
 	std::cout << "    order_verts_by_edgs: adj_edges is empty" << std::endl;
         return moab::MB_FAILURE;
@@ -484,7 +472,6 @@ namespace arc {
       std::vector<moab::EntityHandle> curve;
       result = get_meshset( *i, curve );
       assert(moab::MB_SUCCESS == result);
-      //if(2 > curve.size()) continue;
       assert(1 < curve.size());
       moab::EntityHandle front_endpt = curve[0];
       moab::EntityHandle back_endpt  = curve[curve.size()-1];
@@ -508,21 +495,7 @@ namespace arc {
     //set tree options
     const char settings[]="MAX_PER_LEAF=1;SPLITS_PER_DIR=1;PLANE_SET=0;MESHSET_FLAGS=0x1;TAG_NAME=0";
     moab::FileOptions fileopts(settings);
-
-    /* Old settings for the KD Tree                                            
-    // initialize settings of the KD Tree
-    moab::AdaptiveKDTree::Settings settings;
-    // sets the tree to split any leaves with more than 1 entity                
-    settings.maxEntPerLeaf = 1;                                 
-    // tells the tree how many candidate planes to consider for each dim of the tree                    
-    settings.candidateSplitsPerDir = 1;                           
-    // planes are set to be at evenly spaced intervals
-    settings.candidatePlaneSet = moab::AdaptiveKDTree::SUBDIVISION; 
-    */
     
-
-
-
     // initialize the tree and pass the root entity handle back into root
     result = kdtree.build_tree( endpoints, &root, &fileopts);            
     assert(moab::MB_SUCCESS == result);      
@@ -536,11 +509,9 @@ namespace arc {
       result = get_meshset( *i, curve_i_verts );
       assert(moab::MB_SUCCESS == result);
       double curve_length = gen::length( curve_i_verts );
-      //if(2 > curve.size()) continue; // HANDLE SPECIAL CASES (add logic)     
       if(curve_i_verts.empty()) continue;
       moab::EntityHandle endpts[2] = { curve_i_verts.front(), curve_i_verts.back() };
       moab::CartVect endpt_coords;
-      //if( endpts[0] == endpts[1]) continue; // special case of point curve or circle
       std::vector<moab::EntityHandle> leaves;
 
       // initialize an array which will contain matched of front points in [0] and 
@@ -695,7 +666,4 @@ namespace arc {
     }
     return moab::MB_SUCCESS;
   }
-
-
-
 }

--- a/make_watertight/cleanup.cpp
+++ b/make_watertight/cleanup.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include "cleanup.hpp"
-//#include "MBAdaptiveKDTree.hpp"
 #include "moab/OrientedBoxTreeTool.hpp"
 
 namespace cleanup {
@@ -31,8 +30,6 @@ namespace cleanup {
 						    &obbTag, 0, 1, obb_entities );
     assert(moab::MB_SUCCESS == result);
     std::cout << "  found " << obb_entities.size() << " OBB entities" << std::endl;
-    //gen::print_range( obb_entities );
-    //result = MBI()->delete_entities( obb_entities );
  
     // find tree roots
     moab::Range trees;
@@ -42,7 +39,6 @@ namespace cleanup {
       moab::EntityHandle root;
       result = MBI()->tag_get_data( obbTag, &(*i), 1, &root );
       if(gen::error(moab::MB_SUCCESS!=result, "coule not get OBB tree data")) return result;
-      //assert(moab::MB_SUCCESS == result);
       tool.delete_tree( root );
     }
     result = MBI()->tag_delete( obbTag ); // use this for DENSE tags
@@ -52,21 +48,6 @@ namespace cleanup {
     result = MBI()->tag_get_handle ( "OBB", sizeof(double), 
      				  moab::MB_TYPE_DOUBLE, rootTag, moab::MB_TAG_SPARSE, 0, false);
     assert(moab::MB_SUCCESS==result || moab::MB_ALREADY_ALLOCATED==result);
-    /*    result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET, &rootTag, 
-                                                   NULL, 1, trees );
-    if(moab::MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
-    assert(moab::MB_SUCCESS == result);
-    //tool.find_all_trees( trees );
-    std::cout << trees.size() << " tree(s) contained in file" << std::endl;
-    //gen::print_range( trees );
-  
-    // delete the trees
-    for (moab::Range::iterator i = trees.begin(); i != trees.end(); ++i) {
-      result = tool.delete_tree( *i );
-      //if(moab::MB_SUCCESS != result) std::cout << "result=" << result << std::endl;
-      //assert(moab::MB_SUCCESS == result);
-    }
-    */ 
     // Were all of the trees deleted? Perhaps some of the roots we found were
     // child roots that got deleted with their parents.
     trees.clear();
@@ -189,7 +170,6 @@ namespace cleanup {
 	    std::cout << "adj_edges0.size()=" << adj_edges0.size() 
 		      << " epts[0]=" << epts[0] << std::endl;
 	    MBI()->list_entity( epts[0] );
-	    //MBI()->write_mesh( "test_output.h5m" );
 	    assert(moab::MB_SUCCESS == result);
 	  }
 	  assert(3 <= adj_edges0.size());
@@ -205,7 +185,6 @@ namespace cleanup {
 	    std::cout << "adj_edges1.size()=" << adj_edges1.size() 
 		      << " epts[1]=" << epts[1] << std::endl;
 	    MBI()->list_entity( epts[1] );
-	    //MBI()->write_mesh( "test_output.h5m" );
 	    assert(moab::MB_SUCCESS == result);
 	  }
 	  assert(3 <= adj_edges1.size());
@@ -221,7 +200,6 @@ namespace cleanup {
           std::cout << "adj_edges0.size()=" << adj_edges0.size() 
                     << " endpts[0]=" << endpts[0] << std::endl;
           MBI()->list_entity( endpts[0] );
-          //MBI()->write_mesh( "test_output.h5m" );
           assert(moab::MB_SUCCESS == result);
         }
         assert(3 <= adj_edges0.size());
@@ -237,7 +215,6 @@ namespace cleanup {
           std::cout << "adj_edges1.size()=" << adj_edges1.size() 
                     << " endpts[1]=" << endpts[1] << std::endl;
           MBI()->list_entity( endpts[1] );
-          //MBI()->write_mesh( "test_output.h5m" );
           assert(moab::MB_SUCCESS == result);
         }
         assert(3 <= adj_edges1.size());
@@ -289,44 +266,6 @@ namespace cleanup {
         assert(moab::MB_SUCCESS == result);
         assert(1 == tri1_delete_edge.size());      
 
-        // When an edge is merged, it will be deleted and its to adjacent tris
-        // will be deleted because they are degenerate. We cannot alter the skin.
-        // How many skin edges does tri0 have?
-	/*        moab::Range tri_edges;
-        result = MBI()->get_adjacencies( &adj_tris[0], 1, 1, false, tri_edges );
-        assert(moab::MB_SUCCESS == result);
-        assert(3 == tri_edges.size());
-        moab::Range tri0_internal_edges = intersect(tri_edges, internal_edges);
-
-        // Cannot merge the edge away if the tri has more than one skin edge.
-        // Otherwise we would delete a skin edge. We already know the edges in 
-        // edge_set are not on the skin.
-        if(2 > tri0_internal_edges.size()) continue;
-
-        // check the other tri
-        tri_edges.clear();
-        result = MBI()->get_adjacencies( &adj_tris[1], 1, 1, false, tri_edges );
-        assert(moab::MB_SUCCESS == result);
-        assert(3 == tri_edges.size());
-        moab::Range tri1_internal_edges = intersect(tri_edges, internal_edges);
-        if(2 > tri1_internal_edges.size()) continue;
-
-        // Check to make sure that the internal edges are not on the skin
-        moab::Range temp;
-        temp = intersect( tri0_internal_edges, skin_edges );
-        assert(temp.empty());
-        temp = intersect( tri1_internal_edges, skin_edges );
-        assert(temp.empty());
-
-        // We know that the edge will be merged away. Find the keep_vert and
-        // delete_vert. The delete_vert should never be a skin vertex because the
-        // skin must not move.
-        moab::Range delete_vert;
-        result = MBI()->get_adjacencies( tri0_internal_edges, 0, false, delete_vert);
-        assert(moab::MB_SUCCESS == result);
-        assert(1 == delete_vert.size());        
-	*/
-
         // *********************************************************************
         // Test to see if the merge would create inverted tris. Several special
         // cases to avoid all result in inverted tris.
@@ -362,8 +301,6 @@ namespace cleanup {
 	std::cout << "A merge will occur" << std::endl;
       	gen::print_triangle( adj_tris[0], true );
 	gen::print_triangle( adj_tris[1], true );
-        //tri0_internal_edges.erase( *j );
-        //tri1_internal_edges.erase( *j );
         internal_edges.erase( tri0_delete_edge.front() );
         internal_edges.erase( tri1_delete_edge.front() );
 	std::cout << "merged verts=" << keep_endpt << " " << delete_endpt << std::endl;
@@ -433,13 +370,10 @@ namespace cleanup {
     assert(moab::MB_SUCCESS == result);
 
     // delete the edges that are not in curves.
-    //moab::Range edges_to_delete = all_edges.subtract( edges_to_keep );
     moab::Range edges_to_delete = subtract( all_edges, edges_to_keep );
     std::cout << "deleting " << edges_to_delete.size() << " unused edges" << std::endl;
     result = MBI()->delete_entities( edges_to_delete );
     assert(moab::MB_SUCCESS == result);
     return moab::MB_SUCCESS;
-  }
- 
-  
+  }  
 }

--- a/make_watertight/gen.hpp
+++ b/make_watertight/gen.hpp
@@ -59,26 +59,19 @@ moab::ErrorCode find_closest_vert( const moab::EntityHandle reference_vert,
                                  const std::vector<moab::EntityHandle> loop_of_verts,
                                  std::vector<unsigned> &positions, 
                                  std::vector<double>   &dists);
-  /*  moab::ErrorCode find_closest_vert( const moab::EntityHandle reference_vert,
-                                  const std::vector<std::vector<moab::EntityHandle> > loops_of_verts,
-                                  unsigned int &loop, unsigned int &position, 
-                                  double &min_dist);
-  */
-  // Merge the range of vertices. We do not merge by edges (more
-  // stringent) because we do not want to miss corner vertices.
 
+// Merge the range of vertices. We do not merge by edges (more
+// stringent) because we do not want to miss corner vertices.
 /// finds any vertices within the moab::Range vertices that are with in tol of 
 /// each other and merges them
   moab::ErrorCode merge_vertices( moab::Range vertices /* in */, 
 			      const  double tol       /* in */);
-			      //bool &merge_vertices_again /* out */);
 
 /// returns the square of the distance between v0 and v1
   moab::ErrorCode squared_dist_between_verts( const moab::EntityHandle v0, 
                                           const moab::EntityHandle v1, 
                                           double &d);
 /// returns the distance between v0 and v1
-
   double dist_between_verts( const moab::CartVect v0, const moab::CartVect v1 );
   moab::ErrorCode dist_between_verts( const moab::EntityHandle v0, const moab::EntityHandle v1,
                                   double &d );
@@ -95,7 +88,6 @@ moab::ErrorCode find_closest_vert( const moab::EntityHandle reference_vert,
   bool edges_adjacent( moab::EntityHandle edge0, moab::EntityHandle edge1 );
 
 // get the direction unit vector from one vertex to another vertex
-  //moab::ErrorCode get_direction( moab::EntityHandle from_vert, moab::EntityHandle to_vert, double dir[] );
   moab::ErrorCode get_direction( const moab::EntityHandle from_vert, const moab::EntityHandle to_vert,
                            moab::CartVect &dir ); 
 
@@ -181,14 +173,12 @@ moab::ErrorCode find_closest_vert( const moab::EntityHandle reference_vert,
   };
   int compare_edge(const void *a, const void *b);
   moab::ErrorCode find_skin( moab::Range tris, const int dim,                     
-			 // std::vector<std::vector<moab::EntityHandle> > &skin_edges,    
 			 moab::Range &skin_edges,                         
                          const bool );
-  //moab::ErrorCode find_skin( const moab::Range tris, const int dim, moab::Range &skin_edges, const bool );
+
   moab::ErrorCode measure( const moab::EntityHandle set, const moab::Tag geom_tag, double &size, bool debug, bool verbose );
 
   // Given a curve and surface set, get the relative sense.
-  // From CGMA/builds/dbg/include/CubitDefines, CUBIT_UNKNOWN=-1, CUBIT_FORWARD=0, CUBIT_REVERSED=1
   moab::ErrorCode get_curve_surf_sense( const moab::EntityHandle surf_set, const moab::EntityHandle curve_set,
                                     int &sense, bool debug = false );
 

--- a/make_watertight/make_watertight.cpp
+++ b/make_watertight/make_watertight.cpp
@@ -147,9 +147,6 @@ moab::ErrorCode write_sealed_file( std::string root_filename, double facet_tol, 
     } else {
       output_filename = root_filename + "_zip.h5m";
     }
-    // PROBLEM: If I write the input meshset the writer returns moab::MB_FAILURE.
-    // This happens only if I delete vertices when merging.
-    // result = MBI()->write_mesh( filename_new.c_str(), &input_meshset, 1);
     result = MBI()->write_mesh( output_filename.c_str() );
     if (moab::MB_SUCCESS != result) std::cout << "result= " << result << std::endl;
     assert(moab::MB_SUCCESS == result);  

--- a/make_watertight/post_process.cpp
+++ b/make_watertight/post_process.cpp
@@ -36,9 +36,6 @@
 #include "zip.hpp"
 #include "cleanup.hpp"
 
-
-
-
 moab::Interface *MBI();
 
 moab::ErrorCode delete_all_edges() {
@@ -217,8 +214,6 @@ moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
 	std::vector<moab::EntityHandle>::iterator k=find(unmerged_curve_sets.begin(), 
 	  unmerged_curve_sets.end(), curve);
         if(unmerged_curve_sets.end() == k) {
-  	  //std::cout << "  curve " << gen::geom_id_by_handle(*k) 
-          //          << " is entity_to_keep" << std::endl;
           unmerged_curve_sets.push_back(curve);
         } else {
           unmerged_curve_sets.erase(k);
@@ -292,15 +287,9 @@ moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
 
       /* Get the curves that are part of the surface. Use vectors to store all curve
 	 stuff so that we can remove curves from the set as they are zipped. */
-      //curve_sets.clear();
-
-      //result = MBI()->get_child_meshsets( *i, curve_sets );
-      //assert(moab::MB_SUCCESS==result);
       std::vector<int> curve_ids;
       int curve_id;
       std::vector<std::vector<moab::EntityHandle> > curves;
-      //for(moab::Range::iterator j=curve_sets.begin(); j!=curve_sets.end(); j++) {
-      //for(unsigned int j=0; j<curve_sets.size(); j++) {
       for(std::vector<moab::EntityHandle>::iterator j=curve_sets.begin(); 
         j!=curve_sets.end(); j++) {
 
@@ -308,13 +297,11 @@ moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
         // for duplicates because we are using vectors instead of ranges. Note that
         // parent-child links also cannot store duplicate handles.
         moab::EntityHandle merged_curve;
-	//moab::EntityHandle temp = curve_sets[j];
         result = MBI()->tag_get_data( merge_tag, &(*j), 1, &merged_curve );     
         assert(moab::MB_TAG_NOT_FOUND==result || moab::MB_SUCCESS==result);
         if(moab::MB_SUCCESS == result) *j = merged_curve;
 
 	// do not add a curve if it contains nothing
-	//temp = curve_sets[j];
 	result = MBI()->tag_get_data( id_tag, &(*j), 1, &curve_id );
 	assert(moab::MB_SUCCESS == result);
 	std::cout << "  curve_id=" << curve_id << " handle=" << *j << std::endl;
@@ -328,15 +315,10 @@ moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
       // Keep zipping loops until each is either zipped or failed. This function
       // returns only after all loops are zipped or a failure occurs.
       while(!skin.empty()) {
-        //result = zip_loop( normal_tag, FACET_TOL, MERGE_TOL, 
-	//                 curves, skin, curve_ids, *i, curve_sets );
         if(moab::MB_SUCCESS != result) {
 	  std::cout << "SURFACE_ZIPPING_FAILURE: could not zip surf_id=" << surf_id << std::endl;
         }
       }
-
-      // mod13surf2996, 3028 and 2997 are adjacent to the same bad geometry (figure 8 loop)
-      //assert(moab::MB_SUCCESS==result || 2996==surf_id || 2997==surf_id || 3028==surf_id);
     }
     return moab::MB_SUCCESS;
   }
@@ -409,8 +391,6 @@ moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
       result = MBI()->get_entities_by_type_and_tag( 0, moab::MBENTITYSET, &geom_tag,
 	  					    val, 1, geom_sets[dim] );
       assert(moab::MB_SUCCESS == result);
-      // make sure that sets TRACK membership and curves are ordered
-      // moab::MESHSET_TRACK_OWNER=0x1, moab::MESHSET_SET=0x2, moab::MESHSET_ORDERED=0x4
       for(moab::Range::iterator i=geom_sets[dim].begin(); i!=geom_sets[dim].end(); i++) {
         unsigned int options;
         result = MBI()->get_meshset_options(*i, options );
@@ -438,9 +418,6 @@ moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
     assert(moab::MB_SUCCESS == result);
   
     std::string output_filename = root_name + "_tri.h5m";
-    // PROBLEM: If I write the input meshset the writer returns moab::MB_FAILURE.
-    // This happens only if I delete vertices when merging.
-    // result = MBI()->write_mesh( filename_new.c_str(), &input_meshset, 1);
     result = MBI()->write_mesh( output_filename.c_str() );
     if (moab::MB_SUCCESS != result) std::cout << "result= " << result << std::endl;
     assert(moab::MB_SUCCESS == result);


### PR DESCRIPTION
This is a coarse cleanup of commented code in make_watertight as requested by @gonuke after the update to the new MOAB 4.9.0 header conventions.

