### PR TITLE
removed doxygen as default build option

### DIFF
--- a/make_watertight/Makefile
+++ b/make_watertight/Makefile
@@ -9,7 +9,7 @@ CPPFLAGS += ${MOAB_INCLUDES} -g
 CFLAGS   += ${MOAB_CFLAGS} -g
 # add -g -pg to both CXX and LD flags to profile
 
-all: make_watertight post_process check_watertight fix doxy
+all: make_watertight post_process check_watertight fix 
 
 gen.o: gen.cpp gen.hpp
 	$(CC) $(CXXFLAGS) ${MOAB_INCLUDES} -c gen.cpp


### PR DESCRIPTION
Its confusing for users that build make_wateright when they see that a build failed, make_watertight is built correctly, but looks like a whole build error entirely due to doxygen not being found. This PR mean that when doing make, we do not build dox, instead if dox are wanted a seperate make dox would be needed. @Pshriwise can you review?